### PR TITLE
Use a gembox 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.gembox linguist-language=Ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix a typo in the README.md
 - Remove SimpleHTTPServer
 - Slight refactor of build pipeline
+- Group mruby gems in a gembox
 
 ## v0.3.14.1
 

--- a/scripts/mruby/android.rb
+++ b/scripts/mruby/android.rb
@@ -10,23 +10,5 @@ MRuby::CrossBuild.new("android") do |conf|
   conf.cc.flags += %w[-DMRB_ARY_LENGTH_MAX=0 -DMRB_STR_LENGTH_MAX=0]
   conf.cc.flags += %w[-O2]
 
-  # These are the default libraries
-  conf.gembox "stdlib"
-  conf.gembox "stdlib-ext"
-  conf.gembox "stdlib-io"
-  conf.gembox "math"
-  conf.gembox "metaprog"
-
-  conf.gem core: "mruby-exit"
-  conf.gem core: "mruby-sleep"
-  conf.gem github: "iij/mruby-dir"
-  conf.gem github: "iij/mruby-env"
-  conf.gem github: "iij/mruby-iijson"
-  conf.gem github: "iij/mruby-mtest"
-  conf.gem github: "hellrok/mruby-regexp-pcre"
-  conf.gem github: "hellrok/mruby-tiny-opt-parser"
-  conf.gem github: "Asmod4n/mruby-uri-parser"
-  conf.gem github: "matsumotory/mruby-simplehttp"
-  conf.gem github: "mattn/mruby-base64"
-  conf.gem github: "mattn/mruby-require"
+  conf.gembox File.expand_path('taylor', File.dirname(__FILE__))
 end

--- a/scripts/mruby/darwin_apple.rb
+++ b/scripts/mruby/darwin_apple.rb
@@ -13,23 +13,5 @@ MRuby::CrossBuild.new("osx-apple") do |conf|
   conf.build_target = "arm64-pc-linux-gnu"
   conf.host_target = "arm64-apple-darwin20.4"
 
-  # These are the default libraries
-  conf.gembox "stdlib"
-  conf.gembox "stdlib-ext"
-  conf.gembox "stdlib-io"
-  conf.gembox "math"
-  conf.gembox "metaprog"
-
-  conf.gem core: "mruby-exit"
-  conf.gem core: "mruby-sleep"
-  conf.gem github: "iij/mruby-dir"
-  conf.gem github: "iij/mruby-env"
-  conf.gem github: "iij/mruby-iijson"
-  conf.gem github: "iij/mruby-mtest"
-  conf.gem github: "hellrok/mruby-regexp-pcre"
-  conf.gem github: "hellrok/mruby-tiny-opt-parser"
-  conf.gem github: "Asmod4n/mruby-uri-parser"
-  conf.gem github: "matsumotory/mruby-simplehttp"
-  conf.gem github: "mattn/mruby-base64"
-  conf.gem github: "mattn/mruby-require"
+  conf.gembox File.expand_path('taylor', File.dirname(__FILE__))
 end

--- a/scripts/mruby/darwin_intel.rb
+++ b/scripts/mruby/darwin_intel.rb
@@ -13,23 +13,5 @@ MRuby::CrossBuild.new("osx-intel") do |conf|
   conf.build_target = "x86_64-pc-linux-gnu"
   conf.host_target = "x86_64-apple-darwin20.4"
 
-  # These are the default libraries
-  conf.gembox "stdlib"
-  conf.gembox "stdlib-ext"
-  conf.gembox "stdlib-io"
-  conf.gembox "math"
-  conf.gembox "metaprog"
-
-  conf.gem core: "mruby-exit"
-  conf.gem core: "mruby-sleep"
-  conf.gem github: "iij/mruby-dir"
-  conf.gem github: "iij/mruby-env"
-  conf.gem github: "iij/mruby-iijson"
-  conf.gem github: "iij/mruby-mtest"
-  conf.gem github: "hellrok/mruby-regexp-pcre"
-  conf.gem github: "hellrok/mruby-tiny-opt-parser"
-  conf.gem github: "Asmod4n/mruby-uri-parser"
-  conf.gem github: "matsumotory/mruby-simplehttp"
-  conf.gem github: "mattn/mruby-base64"
-  conf.gem github: "mattn/mruby-require"
+  conf.gembox File.expand_path('taylor', File.dirname(__FILE__))
 end

--- a/scripts/mruby/emscripten.rb
+++ b/scripts/mruby/emscripten.rb
@@ -8,23 +8,5 @@ MRuby::CrossBuild.new("emscripten") do |conf|
   conf.linker.command = "emcc"
   conf.archiver.command = "emar"
 
-  # These are the default libraries
-  conf.gembox "stdlib"
-  conf.gembox "stdlib-ext"
-  conf.gembox "stdlib-io"
-  conf.gembox "math"
-  conf.gembox "metaprog"
-
-  conf.gem core: "mruby-exit"
-  conf.gem core: "mruby-sleep"
-  conf.gem github: "iij/mruby-dir"
-  conf.gem github: "iij/mruby-env"
-  conf.gem github: "iij/mruby-iijson"
-  conf.gem github: "iij/mruby-mtest"
-  conf.gem github: "hellrok/mruby-regexp-pcre"
-  conf.gem github: "hellrok/mruby-tiny-opt-parser"
-  conf.gem github: "Asmod4n/mruby-uri-parser"
-  conf.gem github: "matsumotory/mruby-simplehttp"
-  conf.gem github: "mattn/mruby-base64"
-  conf.gem github: "mattn/mruby-require"
+  conf.gembox File.expand_path('taylor', File.dirname(__FILE__))
 end

--- a/scripts/mruby/linux.rb
+++ b/scripts/mruby/linux.rb
@@ -4,26 +4,8 @@ MRuby::Build.new do |conf|
   conf.cc.flags += %w[-DMRB_ARY_LENGTH_MAX=0 -DMRB_STR_LENGTH_MAX=0]
   conf.cc.flags += %w[-O2]
 
-  # These are the default libraries
-  conf.gembox "stdlib"
-  conf.gembox "stdlib-ext"
-  conf.gembox "stdlib-io"
-  conf.gembox "math"
-  conf.gembox "metaprog"
-
   # Generate mrbc command
   conf.gem core: "mruby-bin-mrbc"
 
-  conf.gem core: "mruby-exit"
-  conf.gem core: "mruby-sleep"
-  conf.gem github: "iij/mruby-dir"
-  conf.gem github: "iij/mruby-env"
-  conf.gem github: "iij/mruby-iijson"
-  conf.gem github: "iij/mruby-mtest"
-  conf.gem github: "hellrok/mruby-regexp-pcre"
-  conf.gem github: "hellrok/mruby-tiny-opt-parser"
-  conf.gem github: "Asmod4n/mruby-uri-parser"
-  conf.gem github: "matsumotory/mruby-simplehttp"
-  conf.gem github: "mattn/mruby-base64"
-  conf.gem github: "mattn/mruby-require"
+  conf.gembox File.expand_path('taylor', File.dirname(__FILE__))
 end

--- a/scripts/mruby/mingw.rb
+++ b/scripts/mruby/mingw.rb
@@ -11,23 +11,5 @@ MRuby::CrossBuild.new("windows") do |conf|
   conf.archiver.command = "#{conf.host_target}-gcc-ar"
   conf.exts.executable = ".exe"
 
-  # These are the default libraries
-  conf.gembox "stdlib"
-  conf.gembox "stdlib-ext"
-  conf.gembox "stdlib-io"
-  conf.gembox "math"
-  conf.gembox "metaprog"
-
-  conf.gem core: "mruby-exit"
-  conf.gem core: "mruby-sleep"
-  conf.gem github: "iij/mruby-dir"
-  conf.gem github: "iij/mruby-env"
-  conf.gem github: "iij/mruby-iijson"
-  conf.gem github: "iij/mruby-mtest"
-  conf.gem github: "hellrok/mruby-regexp-pcre"
-  conf.gem github: "hellrok/mruby-tiny-opt-parser"
-  conf.gem github: "Asmod4n/mruby-uri-parser"
-  conf.gem github: "matsumotory/mruby-simplehttp"
-  conf.gem github: "mattn/mruby-base64"
-  conf.gem github: "mattn/mruby-require"
+  conf.gembox File.expand_path('taylor', File.dirname(__FILE__))
 end

--- a/scripts/mruby/taylor.gembox
+++ b/scripts/mruby/taylor.gembox
@@ -1,0 +1,21 @@
+MRuby::Gembox.new do |conf|
+  # These are the default libraries
+  conf.gembox "stdlib"
+  conf.gembox "stdlib-ext"
+  conf.gembox "stdlib-io"
+  conf.gembox "math"
+  conf.gembox "metaprog"
+
+  conf.gem core: "mruby-exit"
+  conf.gem core: "mruby-sleep"
+  conf.gem github: "iij/mruby-dir"
+  conf.gem github: "iij/mruby-env"
+  conf.gem github: "iij/mruby-iijson"
+  conf.gem github: "iij/mruby-mtest"
+  conf.gem github: "hellrok/mruby-regexp-pcre"
+  conf.gem github: "hellrok/mruby-tiny-opt-parser"
+  conf.gem github: "Asmod4n/mruby-uri-parser"
+  conf.gem github: "matsumotory/mruby-simplehttp"
+  conf.gem github: "mattn/mruby-base64"
+  conf.gem github: "mattn/mruby-require"
+end


### PR DESCRIPTION
We can use a [gembox](https://github.com/mruby/mruby/blob/master/doc/guides/mrbgems.md#gembox) to group all the mgems needed to compile MRuby, this way we can avoid repetition in the build configuration of each platform.