### PR TITLE
Fix Documentation Grammar In Audio, Core & Top Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
 # Taylor
+
+⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 
+Taylor is currently under going a major refactor, if you'd like to do a PR
+please do it against the
+[major refactor](https://github.com/HellRok/Taylor/tree/major-refactor)
+branch.
+⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ ⚠️ 
+
 ## Made for Games
 
 [![Build status](https://badge.buildkite.com/0cb81ca8e3b8f43a2998bc15f90323a2eb8429669e819b7697.svg)](https://buildkite.com/oequacki/taylor)

--- a/mrb_doc/audio/device.rb
+++ b/mrb_doc/audio/device.rb
@@ -1,4 +1,4 @@
-# Initialises the audio device for playback
+# Initialises the audio device for playback.
 # @return [nil]
 def init_audio_device
   # mrb_init_audio_device
@@ -6,7 +6,7 @@ def init_audio_device
   nil
 end
 
-# Closes the audio device
+# Closes the audio device.
 # @return [nil]
 def close_audio_device
   # mrb_close_audio_device
@@ -14,7 +14,7 @@ def close_audio_device
   nil
 end
 
-# Returns if the audio device has been setup
+# Returns if the audio device has been setup.
 # @return [Boolean]
 def audio_device_ready?
   # mrb_audio_device_ready
@@ -22,8 +22,8 @@ def audio_device_ready?
   true
 end
 
-# Sets the master volume
-# @param volume [Float] a value between 0.0 and 1.0
+# Sets the master volume.
+# @param volume [Float] A value between 0.0 and 1.0.
 # @return [nil]
 def set_master_volume(volume)
   # mrb_set_master_volume

--- a/mrb_doc/audio/music.rb
+++ b/mrb_doc/audio/music.rb
@@ -1,4 +1,4 @@
-# Loads a music object from a file
+# Loads a music object from a file.
 # @param path [String]
 # @return [Music]
 def load_music_stream(path)
@@ -7,7 +7,7 @@ def load_music_stream(path)
   Music.new
 end
 
-# Unloads a music object
+# Unloads a music object.
 # @param music [Music]
 # @return [nil]
 def unload_music_stream(music)
@@ -16,7 +16,7 @@ def unload_music_stream(music)
   nil
 end
 
-# Starts playback of a music object from the beginning
+# Starts playback of a music object from the beginning.
 # @param music [Music]
 # @return [nil]
 def play_music_stream(music)
@@ -25,7 +25,7 @@ def play_music_stream(music)
   nil
 end
 
-# Checks whether or not a music object is currently playing
+# Checks whether or not a music object is currently playing.
 # @param music [Music]
 # @return [Boolean]
 def music_playing?(music)
@@ -34,7 +34,7 @@ def music_playing?(music)
   true
 end
 
-# Updates the buffer for the specified music, you should call this every frame
+# Updates the buffer for the specified music, you should call this every frame.
 # @param music [Music]
 # @return [nil]
 def update_music_stream(music)
@@ -43,7 +43,7 @@ def update_music_stream(music)
   nil
 end
 
-# Stops a music object from playing
+# Stops a music object from playing.
 # @param music [Music]
 # @return [nil]
 def stop_music_stream(music)
@@ -52,7 +52,7 @@ def stop_music_stream(music)
   nil
 end
 
-# Pauses a music object so it can be resumed
+# Pauses a music object so it can be resumed.
 # @param music [Music]
 # @return [nil]
 def pause_music_stream(music)
@@ -61,7 +61,7 @@ def pause_music_stream(music)
   nil
 end
 
-# Resumes a paused music object
+# Resumes a paused music object.
 # @param music [Music]
 # @return [nil]
 def resume_music_stream(music)
@@ -70,9 +70,9 @@ def resume_music_stream(music)
   nil
 end
 
-# Sets volume for a music object
+# Sets volume for a music object.
 # @param music [Music]
-# @param volume [Float] A value between 0.0 and 1.0
+# @param volume [Float] A value between 0.0 and 1.0.
 # @return [nil]
 def set_music_volume(music, volume)
   # mrb_set_music_volume
@@ -80,7 +80,7 @@ def set_music_volume(music, volume)
   nil
 end
 
-# Sets pitch for a music object
+# Sets pitch for a music object.
 # @param music [Music]
 # @param pitch [Float]
 # @return [nil]
@@ -90,18 +90,18 @@ def set_music_pitch(music, pitch)
   nil
 end
 
-# Gets the length of a music object in seconds
+# Gets the length of a music object in seconds.
 # @param music [Music]
-# @return [Float] The length of the music object is seconds
+# @return [Float] The length of the music object is seconds.
 def get_music_time_length(music)
   # mrb_get_music_time_length
   # src/mruby_integration/audio/music.cpp
   nil
 end
 
-# Gets the time played of a music object in seconds
+# Gets the time played of a music object in seconds.
 # @param music [Music]
-# @return [Float] The length of the music object is seconds
+# @return [Float] The length of the music object is seconds.
 def get_music_time_played(music)
   # mrb_get_music_time_played
   # src/mruby_integration/audio/music.cpp

--- a/mrb_doc/audio/sound.rb
+++ b/mrb_doc/audio/sound.rb
@@ -1,4 +1,4 @@
-# Loads a sound object from a file
+# Loads a sound object from a file.
 # @param path [String]
 # @return [Sound]
 def load_sound(path)
@@ -7,7 +7,7 @@ def load_sound(path)
   Sound.new
 end
 
-# Unloads a sound object
+# Unloads a sound object.
 # @param sound [Sound]
 # @return [nil]
 def unload_sound(sound)
@@ -16,7 +16,7 @@ def unload_sound(sound)
   nil
 end
 
-# Plays a sound object
+# Plays a sound object.
 # @param sound [Sound]
 # @return [nil]
 def play_sound(sound)
@@ -25,7 +25,7 @@ def play_sound(sound)
   nil
 end
 
-# Stops a sound object
+# Stops a sound object.
 # @param sound [Sound]
 # @return [nil]
 def stop_sound(sound)
@@ -34,7 +34,7 @@ def stop_sound(sound)
   nil
 end
 
-# Pauses a sound object so it can be resumed
+# Pauses a sound object so it can be resumed.
 # @param sound [Sound]
 # @return [nil]
 def pause_sound(sound)
@@ -43,7 +43,7 @@ def pause_sound(sound)
   nil
 end
 
-# Resumes a paused sound object
+# Resumes a paused sound object.
 # @param sound [Sound]
 # @return [nil]
 def resume_sound(sound)
@@ -52,7 +52,7 @@ def resume_sound(sound)
   nil
 end
 
-# Checks whether or not a sound object is currently playing
+# Checks whether or not a sound object is currently playing.
 # @param sound [Sound]
 # @return [Boolean]
 def sound_playing?(sound)
@@ -61,9 +61,9 @@ def sound_playing?(sound)
   true
 end
 
-# Sets the volume of the sound object
+# Sets the volume of the sound object.
 # @param sound [Sound]
-# @param volume [Float] a value between 0.0 and 1.0
+# @param volume [Float] A value between 0.0 and 1.0.
 # @return [nil]
 def set_sound_volume(sound, volume)
   # mrb_set_sound_volume
@@ -71,7 +71,7 @@ def set_sound_volume(sound, volume)
   1
 end
 
-# Sets the pitch of the sound object
+# Sets the pitch of the sound object.
 # @param sound [Sound]
 # @param pitch [Float]
 # @return [nil]

--- a/mrb_doc/core/cursor.rb
+++ b/mrb_doc/core/cursor.rb
@@ -1,4 +1,4 @@
-# Shows the cursor
+# Shows the cursor.
 # @return [nil]
 def show_cursor
   # mrb_show_cursor
@@ -6,7 +6,7 @@ def show_cursor
   nil
 end
 
-# Hides the cursor
+# Hides the cursor.
 # @return [nil]
 def hide_cursor
   # mrb_hide_cursor
@@ -14,7 +14,7 @@ def hide_cursor
   nil
 end
 
-# Checks if the cursor is hidden
+# Checks if the cursor is hidden.
 # @return [Boolean]
 def cursor_hidden?
   # mrb_cursor_hidden
@@ -22,7 +22,7 @@ def cursor_hidden?
   true
 end
 
-# Enables and shows the cursor
+# Enables and shows the cursor.
 # @return [nil]
 def enable_cursor
   # mrb_enable_cursor
@@ -30,7 +30,7 @@ def enable_cursor
   nil
 end
 
-# Disables the cursor and hides it
+# Disables the cursor and hides it.
 # @return [nil]
 def disable_cursor
   # mrb_disable_cursor
@@ -38,7 +38,7 @@ def disable_cursor
   nil
 end
 
-# Checks if the cursor is in the window
+# Checks if the cursor is in the window.
 # @return [Boolean]
 def cursor_on_screen?
   # mrb_cursor_on_screen

--- a/mrb_doc/core/drawing.rb
+++ b/mrb_doc/core/drawing.rb
@@ -1,4 +1,4 @@
-# Clears the screen with the specified colour
+# Clears the screen with the specified colour.
 # @param colour [Colour]
 # @return [nil]
 def clear_background(colour)
@@ -7,7 +7,7 @@ def clear_background(colour)
   nil
 end
 
-# Starts drawing to the screen
+# Starts drawing to the screen.
 # @return [nil]
 def begin_drawing
   # mrb_begin_drawing
@@ -15,7 +15,7 @@ def begin_drawing
   nil
 end
 
-# Ends drawing to the screen
+# Ends drawing to the screen.
 # @return [nil]
 def end_drawing
   # mrb_end_drawing
@@ -23,7 +23,28 @@ def end_drawing
   nil
 end
 
+<<<<<<< HEAD
 # Starts drawing to the RenderTexture
+=======
+# Starts drawing from the perspective of the camera.
+# @param camera [Camera2D]
+# @return [nil]
+def begin_mode2D(camera)
+  # mrb_begin_mode2D
+  # src/mruby_integration/core/drawing.cpp
+  nil
+end
+
+# Stops drawing from the perspective of the camera.
+# @return [nil]
+def end_mode2D
+  # mrb_end_mode2D
+  # src/mruby_integration/core/drawing.cpp
+  nil
+end
+
+# Starts drawing to the {RenderTexture}.
+>>>>>>> aea7c7f62eefa36f5930ba95057904e50b2036d4
 # @param texture [RenderTexture]
 # @return [nil]
 def begin_texture_mode(texture)
@@ -32,7 +53,7 @@ def begin_texture_mode(texture)
   nil
 end
 
-# Stops drawing to the RenderTexture
+# Stops drawing to the {RenderTexture}.
 # @return [nil]
 def end_texture_mode
   # mrb_end_texture_mode
@@ -40,7 +61,7 @@ def end_texture_mode
   nil
 end
 
-# All draw calls within will be drawn through the Shader
+# All draw calls within will be drawn through the {Shader}.
 # @param shader [Shader]
 # @return [nil]
 def begin_shader_mode(shader)
@@ -49,7 +70,7 @@ def begin_shader_mode(shader)
   nil
 end
 
-# Stops drawing through the Shader
+# Stops drawing through the {Shader}.
 # @return [nil]
 def end_shader_mode
   # mrb_end_shader_mode
@@ -57,7 +78,7 @@ def end_shader_mode
   nil
 end
 
-# In scissor mode only draw calls within the defined area will actually be drawn
+# In scissor mode only draw calls within the defined area will actually be drawn.
 # @param x [Integer]
 # @param y [Integer]
 # @param width [Integer]
@@ -69,7 +90,7 @@ def begin_scissor_mode(x, y, width, height)
   nil
 end
 
-# End scissor mode
+# End scissor mode.
 # @return [nil]
 def end_scissor_mode
   # mrb_end_scissor_mode

--- a/mrb_doc/core/files.rb
+++ b/mrb_doc/core/files.rb
@@ -1,4 +1,4 @@
-# Have their been files dropped that haven't been dealt with?
+# Have there been files dropped that haven't been dealt with?
 # @return [nil]
 def files_dropped?
   # mrb_files_dropped

--- a/mrb_doc/core/gestures.rb
+++ b/mrb_doc/core/gestures.rb
@@ -1,5 +1,6 @@
-# Enable only specific gestures, to pass in multiple you can do so like:
-#   `set_gestures_enabled(GESTURE_TAP | GESTURE_SWIPE_UP)`
+# Enable only specific gestures, 
+# @example Passing multiple flags.
+#   set_gestures_enabled(GESTURE_TAP | GESTURE_SWIPE_UP)
 # @param flags [Integer]
 # @return [nil]
 def set_gestures_enabled(flags)
@@ -8,7 +9,7 @@ def set_gestures_enabled(flags)
   nil
 end
 
-# Returns the detected gestures based on their constant
+# Returns the detected gestures based on their constant.
 # @return [Integer]
 def get_gesture_detected
   # mrb_get_gesture_detected

--- a/mrb_doc/core/input/gamepad.rb
+++ b/mrb_doc/core/input/gamepad.rb
@@ -1,4 +1,4 @@
-# Return whether or not the specified gamepad is available
+# Return whether or not the specified gamepad is available.
 # @param index [Integer]
 # @return [Bool]
 def gamepad_available?(index)
@@ -7,7 +7,7 @@ def gamepad_available?(index)
   true
 end
 
-# Returns the specified gamepads name
+# Returns the specified gamepads name.
 # @param index [Integer]
 # @return [String]
 def get_gamepad_name(index)
@@ -56,7 +56,7 @@ def gamepad_button_up?(index, button)
   true
 end
 
-# Returns the last pressed gamepad button
+# Returns the last pressed gamepad button.
 # @return [Integer]
 def get_gamepad_button_pressed
   # mrb_get_gamepad_button_pressed
@@ -64,7 +64,7 @@ def get_gamepad_button_pressed
   0
 end
 
-# Returns the count of axis for the specified gamepad
+# Returns the count of axis for the specified gamepad.
 # @param index [Integer]
 # @return [Integer]
 def get_gamepad_axis_count(index)
@@ -73,10 +73,10 @@ def get_gamepad_axis_count(index)
   2
 end
 
-# Returns the movement of the specified axis for the specified gamepad
+# Returns the movement of the specified axis for the specified gamepad.
 # @param index [Integer]
 # @param axis [Integer]
-# @return [Float] -1.0 to 1.0
+# @return [Float] -1.0 to 1.0.
 def get_gamepad_axis_movement(index, axis)
   # mrb_get_gamepad_axis_movement
   # src/mruby_integration/core/input/gamepad.cpp
@@ -84,7 +84,7 @@ def get_gamepad_axis_movement(index, axis)
 end
 
 # Setup gamepad mappings using the
-# [SDL_GameControllerDB](https://github.com/gabomdq/SDL_GameControllerDB) format
+# [SDL_GameControllerDB](https://github.com/gabomdq/SDL_GameControllerDB) format.
 # @param mappings [String]
 # @return [Integer]
 def set_gamepad_mappings(mappings)

--- a/mrb_doc/core/input/keyboard.rb
+++ b/mrb_doc/core/input/keyboard.rb
@@ -34,7 +34,11 @@ def key_up?(key)
   False
 end
 
+<<<<<<< HEAD
 # Sets the key for should_window_close? to listen for.
+=======
+# Sets the key for {window_should_close?} to listen for.
+>>>>>>> aea7c7f62eefa36f5930ba95057904e50b2036d4
 # @param key [Integer]
 # @return [nil]
 def set_exit_key(key)

--- a/mrb_doc/core/input/keyboard.rb
+++ b/mrb_doc/core/input/keyboard.rb
@@ -34,7 +34,7 @@ def key_up?(key)
   False
 end
 
-# Sets the key for should_window_close? to listen for
+# Sets the key for should_window_close? to listen for.
 # @param key [Integer]
 # @return [nil]
 def set_exit_key(key)
@@ -43,7 +43,7 @@ def set_exit_key(key)
   nil
 end
 
-# Returns the keycode for the pressed key, call it multiple times for queued keys
+# Returns the keycode for the pressed key, call it multiple times for queued keys.
 # @return [Integer]
 def get_key_pressed
   # mrb_get_key_pressed
@@ -51,7 +51,7 @@ def get_key_pressed
   64
 end
 
-# Returns the charcode for the pressed key, call it multiple times for queued keys
+# Returns the charcode for the pressed key, call it multiple times for queued keys.
 # @return [Integer]
 def get_char_pressed
   # mrb_getchar_pressed

--- a/mrb_doc/core/input/mouse.rb
+++ b/mrb_doc/core/input/mouse.rb
@@ -34,7 +34,7 @@ def mouse_button_up?(button)
   false
 end
 
-# Returns the current mouse x position in the window
+# Returns the current mouse x position in the window.
 # @return [Integer]
 def get_mouse_x
   # mrb_get_mouse_x
@@ -42,7 +42,7 @@ def get_mouse_x
   64
 end
 
-# Returns the current mouse y position in the window
+# Returns the current mouse y position in the window.
 # @return [Integer]
 def get_mouse_y
   # mrb_get_mouse_y
@@ -50,7 +50,7 @@ def get_mouse_y
   64
 end
 
-# Returns the current mouse position in the window
+# Returns the current mouse position in the window.
 # @return [Vector2]
 def get_mouse_position
   # mrb_get_mouse_position
@@ -58,7 +58,7 @@ def get_mouse_position
   Vector2.new
 end
 
-# Sets the position of the muose
+# Sets the position of the mouse.
 # @param x [Integer]
 # @param y [Integer]
 # @return [nil]
@@ -68,7 +68,7 @@ def set_mouse_position(x, y)
   nil
 end
 
-# Sets the offset for all mouse position functions
+# Sets the offset for all mouse position functions.
 # @param x [Integer]
 # @param y [Integer]
 # @return [nil]
@@ -78,7 +78,7 @@ def set_mouse_offset(x, y)
   nil
 end
 
-# Sets the scaling for all mouse position functions
+# Sets the scaling for all mouse position functions.
 # @param x [Float]
 # @param y [Float]
 # @return [nil]
@@ -88,7 +88,7 @@ def set_mouse_scale(x, y)
   nil
 end
 
-# Returns the movement of the mouse wheel since last frame
+# Returns the movement of the mouse wheel since last frame.
 # @return [Float]
 def get_mouse_wheel_move
   # mrb_get_mouse_wheel_move
@@ -96,7 +96,7 @@ def get_mouse_wheel_move
   0.5
 end
 
-# Sets the mouse cursor
+# Sets the mouse cursor.
 # @param cursor [Integer]
 # @return [nil]
 def set_mouse_cursor(cursor)

--- a/mrb_doc/core/input/touch.rb
+++ b/mrb_doc/core/input/touch.rb
@@ -1,4 +1,4 @@
-# Get the position within the window of the specified touch
+# Get the position within the window of the specified touch.
 # @param index [Integer]
 # @return [Vector2]
 def get_touch_position(index)

--- a/mrb_doc/core/misc.rb
+++ b/mrb_doc/core/misc.rb
@@ -1,8 +1,6 @@
-# You'll want to call this function after you've called `end_drawing` or you'll
+# You'll want to call this function after you've called {end_drawing} or you'll
 # find that you don't get everything that you think you've drawn.
-#
-# The extension of `filename` will dictate how the screenshot is saved.
-# @param filename [String]
+# @param filename [String] The filename to save to. The extension will dictate how it is saved.
 # @return [nil]
 def take_screenshot(filename)
   # mrb_take_screenshot
@@ -10,8 +8,9 @@ def take_screenshot(filename)
   nil
 end
 
-# Enable specific config flags, to pass in multiple you can do so like:
-#   `set_config_flags(FLAG_WINDOW_TOPMOST | FLAG_WINDOW_RESIZABLE)`
+# Enable specific config flags. 
+# @example Passing multiple flags.
+#   set_config_flags(FLAG_WINDOW_TOPMOST | FLAG_WINDOW_RESIZABLE)
 # @param flags [Integer]
 # @return [nil]
 def set_config_flags(flags)
@@ -20,8 +19,8 @@ def set_config_flags(flags)
   nil
 end
 
-# Sets the logging level
-# @param level [Integer] A value between 0 and 5
+# Sets the logging level.
+# @param level [Integer] A value between 0 and 5.
 # @return [nil]
 def set_trace_log_level(level)
   # mrb_set_trace_log_level
@@ -29,7 +28,7 @@ def set_trace_log_level(level)
   nil
 end
 
-# Opens the URL in the users browser
+# Opens the URL in the user's browser.
 # @param url [String]
 # @return [nil]
 def open_url(url)
@@ -38,7 +37,7 @@ def open_url(url)
   nil
 end
 
-# Sets the clipboard value
+# Sets the clipboard value.
 # @param text [String]
 # @return [nil]
 def set_clipboard_text(text)
@@ -47,7 +46,7 @@ def set_clipboard_text(text)
   nil
 end
 
-# Gets the clipboard value
+# Gets the clipboard value.
 # @return [String]
 def get_clipboard_text
   # mrb_get_clipboard_text

--- a/mrb_doc/core/screen_space.rb
+++ b/mrb_doc/core/screen_space.rb
@@ -1,0 +1,19 @@
+# Translates the vector to where it is on the screen according to the camera.
+# @param vector [Vector2]
+# @param camera [Camera2D]
+# @return [Vector2]
+def get_world_to_screen2D(vector, camera)
+  # mrb_get_world_to_screen2D
+  # src/mruby_integration/core/screen_space.cpp
+  Vector2.new
+end
+
+# Translates the vector to where it is in the world based on it the camera.
+# @param vector [Vector2]
+# @param camera [Camera2D]
+# @return [Vector2]
+def get_screen_to_world2D(vector, camera)
+  # mrb_get_screen_to_world2D
+  # src/mruby_integration/core/screen_space.cpp
+  Vector2.new
+end

--- a/mrb_doc/core/timing.rb
+++ b/mrb_doc/core/timing.rb
@@ -1,4 +1,4 @@
-# Set the framerate you wish to target (usually 60, 120, or 144)
+# Set the framerate you wish to target (usually 60, 120, or 144).
 # @param target [Integer]
 # @return [nil]
 def set_target_fps(target)
@@ -7,7 +7,7 @@ def set_target_fps(target)
   nil
 end
 
-# Returns the current framerate as an integer
+# Returns the current framerate as an integer.
 # @return [Integer]
 def get_fps
   # mrb_get_fps
@@ -15,7 +15,7 @@ def get_fps
   60
 end
 
-# Returns the amount of time the last frame took in seconds
+# Returns the amount of time the last frame took in seconds.
 # @return [Float]
 def get_frame_time
   # mrb_frame_time
@@ -23,7 +23,7 @@ def get_frame_time
   0.01633
 end
 
-# Returns the amount of time the has passed since init_window was called
+# Returns the amount of time the has passed since init_window was called.
 # @return [Float]
 def get_time
   # mrb_time

--- a/mrb_doc/core/window.rb
+++ b/mrb_doc/core/window.rb
@@ -1,4 +1,4 @@
-# Initialises a window for rendering
+# Initialises a window for rendering.
 # @param width [Integer]
 # @param height [Integer]
 # @param title [String]
@@ -17,7 +17,7 @@ def window_should_close?
   false
 end
 
-# Close the open window
+# Close the open window.
 # @return [nil]
 def close_window
   # mrb_close_window
@@ -33,8 +33,9 @@ def window_ready?
   true
 end
 
-# Checks if the window has the state set, to pass in multiple you can do so like:
-#   `window_state?(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)`
+# Checks if the window has the state set.
+# @example Passing multiple flags.
+#   window_state?(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [Boolean]
 def window_state?(flags)
@@ -43,8 +44,9 @@ def window_state?(flags)
   true
 end
 
-# Sets the specified states on the window, to pass in multiple you can do so like:
-#   `set_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)`
+# Sets the specified states on the window.
+# @example Passing multiple flags.
+#   set_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [nil]
 def set_window_state(flags)
@@ -53,7 +55,7 @@ def set_window_state(flags)
   nil
 end
 
-# Checks if the window has the FLAG_FULLSCREEN_MODE state set
+# Checks if the window has the {FLAG_FULLSCREEN_MODE} state set.
 # @return [Boolean]
 def window_fullscreen?
   # mrb_window_fullscreen
@@ -61,7 +63,7 @@ def window_fullscreen?
   true
 end
 
-# Checks if the window has the FLAG_WINDOW_HIDDEN state set
+# Checks if the window has the {FLAG_WINDOW_HIDDEN} state set.
 # @return [Boolean]
 def window_hidden?
   # mrb_window_hidden
@@ -69,7 +71,7 @@ def window_hidden?
   false
 end
 
-# Checks if the window has the FLAG_WINDOW_MINIMISED state set
+# Checks if the window has the {FLAG_WINDOW_MINIMISED} state set.
 # @return [Boolean]
 def window_minimised?
   # mrb_window_minimised
@@ -77,7 +79,7 @@ def window_minimised?
   false
 end
 
-# Checks if the window has the FLAG_WINDOW_MAXIMISED state set
+# Checks if the window has the {FLAG_WINDOW_MAXIMISED} state set.
 # @return [Boolean]
 def window_maximised?
   # mrb_window_maximised
@@ -85,7 +87,7 @@ def window_maximised?
   true
 end
 
-# Checks if the window has focus
+# Checks if the window has focus.
 # @return [Boolean]
 def window_focused?
   # mrb_window_focused
@@ -93,7 +95,7 @@ def window_focused?
   true
 end
 
-# Checks if the window was resized since the last frame
+# Checks if the window was resized since the last frame.
 # @return [Boolean]
 def window_resized?
   # mrb_window_resized
@@ -101,8 +103,9 @@ def window_resized?
   false
 end
 
-# Clears the specified states on the window, to pass in multiple you can do so like:
-#   `clear_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)`
+# Clears the specified states on the window.
+# @example Passing multiple flags.
+#   clear_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [nil]
 def clear_window_state(flags)
@@ -111,7 +114,7 @@ def clear_window_state(flags)
   nil
 end
 
-# Toggles the fullscreen state
+# Toggles the fullscreen state.
 # @return [nil]
 def toggle_fullscreen
   # mrb_toggle_fullscreen
@@ -119,7 +122,7 @@ def toggle_fullscreen
   nil
 end
 
-# Maximises the window
+# Maximises the window.
 # @return [nil]
 def maximise_window
   # mrb_maximise_window
@@ -127,7 +130,7 @@ def maximise_window
   nil
 end
 
-# Minimises the window
+# Minimises the window.
 # @return [nil]
 def minimise_window
   # mrb_minimise_window
@@ -135,8 +138,8 @@ def minimise_window
   nil
 end
 
-# Restores the window from being maximised or minimised
-# @note I don't think it currently works for restoring from minimised
+# Restores the window from being maximised or minimised.
+# @note I don't think it currently works for restoring from minimised.
 # @return [nil]
 def restore_window
   # mrb_restore_window
@@ -144,7 +147,7 @@ def restore_window
   nil
 end
 
-# Sets the icon for the current window
+# Sets the icon for the current window.
 # @param image [Image]
 # @return [nil]
 def set_window_icon(image)
@@ -153,7 +156,7 @@ def set_window_icon(image)
   nil
 end
 
-# Sets the title for the current window
+# Sets the title for the current window.
 # @param title [String]
 # @return [nil]
 def set_window_title(title)
@@ -162,7 +165,7 @@ def set_window_title(title)
   nil
 end
 
-# Sets the position for the current window
+# Sets the position for the current window.
 # @param x [Integer]
 # @param y [Integer]
 # @return [nil]
@@ -172,7 +175,7 @@ def set_window_position(x, y)
   nil
 end
 
-# Sets the monitor for the current window
+# Sets the monitor for the current window.
 # @param monitor [Integer]
 # @return [nil]
 def set_window_monitor(monitor)
@@ -181,7 +184,7 @@ def set_window_monitor(monitor)
   nil
 end
 
-# Sets the minimum allowed size for the current window
+# Sets the minimum allowed size for the current window.
 # @param width [Integer]
 # @param height [Integer]
 # @return [nil]
@@ -191,7 +194,7 @@ def set_window_min_size(width, height)
   nil
 end
 
-# Sets the size for the current window
+# Sets the size for the current window.
 # @param width [Integer]
 # @param height [Integer]
 # @return [nil]
@@ -201,7 +204,7 @@ def set_window_size(width, height)
   nil
 end
 
-# Gets the width of the window
+# Gets the width of the window.
 # @return [Integer]
 def get_screen_width
   # mrb_get_screen_width
@@ -209,7 +212,7 @@ def get_screen_width
   640
 end
 
-# Gets the height of the window
+# Gets the height of the window.
 # @return [Integer]
 def get_screen_height
   # mrb_get_screen_height
@@ -217,7 +220,7 @@ def get_screen_height
   480
 end
 
-# Gets the total number of monitors the user has
+# Gets the total number of monitors the user has.
 # @return [Integer]
 def get_monitor_count
   # mrb_get_monitor_count
@@ -225,7 +228,7 @@ def get_monitor_count
   2
 end
 
-# Gets the id of the current monitor
+# Gets the id of the current monitor.
 # @return [Integer]
 def get_current_monitor
   # mrb_get_current_monitor
@@ -233,7 +236,7 @@ def get_current_monitor
   0
 end
 
-# Gets the position of the specified monitor
+# Gets the position of the specified monitor.
 # @param monitor [Integer]
 # @return [Vector2]
 def get_monitor_position(monitor)
@@ -242,7 +245,7 @@ def get_monitor_position(monitor)
   Vector2.new(0, 0)
 end
 
-# Gets the width of the specified monitor
+# Gets the width of the specified monitor.
 # @param monitor [Integer]
 # @return [Integer]
 def get_monitor_width(monitor)
@@ -251,7 +254,7 @@ def get_monitor_width(monitor)
   1920
 end
 
-# Gets the height of the specified monitor
+# Gets the height of the specified monitor.
 # @param monitor [Integer]
 # @return [Integer]
 def get_monitor_height(monitor)
@@ -260,7 +263,7 @@ def get_monitor_height(monitor)
   1080
 end
 
-# Gets the refresh rate of the specified monitor
+# Gets the refresh rate of the specified monitor.
 # @param monitor [Integer]
 # @return [Integer]
 def get_monitor_refresh_rate(monitor)
@@ -269,7 +272,7 @@ def get_monitor_refresh_rate(monitor)
   60
 end
 
-# Gets the position of the window
+# Gets the position of the window.
 # @return [Vector2]
 def get_window_position
   # mrb_get_window_position
@@ -277,7 +280,7 @@ def get_window_position
   Vector2.new(10, 10)
 end
 
-# Gets the scale of the window
+# Gets the scale of the window.
 # @return [Vector2]
 def get_window_scale_dpi
   # mrb_get_window_scale_dpi

--- a/mrb_doc/image.rb
+++ b/mrb_doc/image.rb
@@ -1,4 +1,187 @@
+<<<<<<< HEAD
 # Inverts the colours of the image
+=======
+# Loads an image from a file.
+# @param path [String]
+# @return [Image]
+def load_image(path)
+  # mrb_load_image
+  # src/mruby_integration/image.cpp
+  Image.new
+end
+
+# Unloads an image.
+# @param image [Image]
+# @return [nil]
+def unload_image(image)
+  # mrb_unload_image
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Exports an image to a file.
+# @param image [Image]
+# @param path [String]
+# @return [nil]
+def export_image(image, path)
+  # mrb_export_image
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Generates a new image of width by height in the specified colour.
+# @param width [Integer]
+# @param height [Integer]
+# @param colour [Colour]
+# @return [Image]
+def generate_image_colour(width, height, colour)
+  # mrb_generate_image_colour
+  # src/mruby_integration/image.cpp
+  Image.new
+end
+
+# Copies an image to a new object.
+# @param image [Image]
+# @return [Image]
+def image_copy(image)
+  # mrb_image_copy
+  # src/mruby_integration/image.cpp
+  Image.new
+end
+
+# Returns a subsection of an image.
+# @param image [Image]
+# @param source [Rectangle]
+# @return [Image]
+def image_from_image(image, source)
+  # mrb_image_from_image
+  # src/mruby_integration/image.cpp
+  Image.new
+end
+
+# Creates an image from the font.
+# @param font [Font] Which font to draw with.
+# @param text [String] The text to put on the screen.
+# @param font_size [Integer]
+# @param font_padding [Integer]
+# @param colour [Colour]
+# @return [Image]
+def image_text_ex(font, text, font_size, font_padding, colour)
+  # mrb_image_text_ex
+  # src/mruby_integration/image.cpp
+  Image.new
+end
+
+# Resizes the image using a bicubic scaling algorithm. Useful for things like
+# photos, not great for pixel art.
+# @param image [Image]
+# @param width [Integer]
+# @param height [Integer]
+# @return [nil]
+def image_resize!(image, width, height)
+  # mrb_image_resize
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Resizes the image using a nearest-neighbour scaling algorithm. Useful for things like
+# pixel art, not great for photos.
+# @param image [Image]
+# @param width [Integer]
+# @param height [Integer]
+# @return [nil]
+def image_resize_nearest_neighbour!(image, width, height)
+  # mrb_image_resize_nearest_neighbour
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Crops the image to the section in the rectangle.
+# @param image [Image]
+# @param rectangle [Rectangle]
+# @return [nil]
+def image_crop!(image, rectangle)
+  # mrb_image_crop
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Applies the alpha of the mask to the image.
+# @param image [Image]
+# @param alpha_mask [Image]
+# @return [nil]
+def image_alpha_mask!(image, alpha_mask)
+  # mrb_image_alpha_mask
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Pre-multiplies the alpha for the image.
+# @param image [Image]
+# @return [nil]
+def image_alpha_premultiply!(image)
+  # mrb_image_alpha_premultiply
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Flips the image vertically.
+# @param image [Image]
+# @return [nil]
+def image_flip_vertical!(image)
+  # mrb_image_flip_vertical
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Generates mipmaps for the specified image.
+# @param image [Image]
+# @return [nil]
+def image_mipmaps!(image)
+  # mrb_image_mipmaps
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Flips the image horizontally.
+# @param image [Image]
+# @return [nil]
+def image_flip_horizontal!(image)
+  # mrb_image_flip_horizontal
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Rotates the image clockwise 90 degrees.
+# @param image [Image]
+# @return [nil]
+def image_rotate_cw!(image)
+  # mrb_image_rotate_cw
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Rotates the image counter-clockwise 90 degrees.
+# @param image [Image]
+# @return [nil]
+def image_rotate_ccw!(image)
+  # mrb_image_rotate_ccw
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Tints the image with the specified colour.
+# @param image [Image]
+# @param colour [Colour]
+# @return [nil]
+def image_colour_tint!(image, colour)
+  # mrb_image_colour_tint
+  # src/mruby_integration/image.cpp
+  nil
+end
+
+# Inverts the colours of the image.
+>>>>>>> aea7c7f62eefa36f5930ba95057904e50b2036d4
 # @param image [Image]
 # @return [nil]
 def image_colour_invert!(image)
@@ -7,7 +190,7 @@ def image_colour_invert!(image)
   nil
 end
 
-# Converts the image to grayscale
+# Converts the image to grayscale.
 # @param image [Image]
 # @return [nil]
 def image_colour_grayscale!(image)
@@ -16,9 +199,9 @@ def image_colour_grayscale!(image)
   nil
 end
 
-# Change the contrast of the image
+# Change the contrast of the image.
 # @param image [Image]
-# @param contrast [Float] a value between -100 and 100
+# @param contrast [Float] A value between -100 and 100.
 # @return [nil]
 def image_colour_contrast!(image, contrast)
   # mrb_image_colour_contrast
@@ -26,9 +209,9 @@ def image_colour_contrast!(image, contrast)
   nil
 end
 
-# Change the brightness of the image
+# Change the brightness of the image.
 # @param image [Image]
-# @param brightness [Float] a value between -255 and 255
+# @param brightness [Float] A value between -255 and 255.
 # @return [nil]
 def image_colour_brightness!(image, brightness)
   # mrb_image_colour_brightness
@@ -36,7 +219,7 @@ def image_colour_brightness!(image, brightness)
   nil
 end
 
-# Replace the old Colour with the new Colour
+# Replace the old Colour with the new Colour.
 # @param image [Image]
 # @param old_colour [Colour]
 # @param new_colour [Colour]
@@ -61,7 +244,7 @@ def image_draw!(destination, source, source_rectangle, destination_rectangle, co
   nil
 end
 
-# Returns an Image object with the screen data
+# Returns an Image object with the screen data.
 # @return [Image]
 def get_screen_data
   # mrb_get_screen_data

--- a/mrb_doc/shaders.rb
+++ b/mrb_doc/shaders.rb
@@ -1,4 +1,4 @@
-# Loads a shader from in memory strings
+# Loads a shader from in memory strings.
 # @param vertex_shader_code [String]
 # @param fragment_shader_code [String]
 # @return [Shader]
@@ -8,7 +8,7 @@ def load_shader_from_string(vertex_shader_code, fragment_shader_code)
   Shader.new
 end
 
-# Loads a shader from a file
+# Loads a shader from a file.
 # @param vertex_shader_path [String]
 # @param fragment_shader_path [String]
 # @return [Shader]
@@ -18,7 +18,7 @@ def load_shader(vertex_shader_path, fragment_shader_path)
   Shader.new
 end
 
-# Unloads a shader
+# Unloads a shader.
 # @param shader [Shader]
 # @return [nil]
 def unload_shader(shader)
@@ -27,7 +27,7 @@ def unload_shader(shader)
   nil
 end
 
-# Checks if the shader is ready
+# Checks if the shader is ready.
 # @param shader [Shader]
 # @return [Boolean]
 def shader_ready?(shader)
@@ -48,9 +48,9 @@ end
 
 # Returns the location of uniform variable, will return -1 if not found.
 # @param shader [Shader]
-# @param variable_location [Integer] The value you got from {get_shader_location}
+# @param variable_location [Integer] The value you got from {get_shader_location}.
 # @param variables [Array]
-# @param variable_type [Integer] Valid options are {Shader::Uniform::FLOAT}, {Shader::Uniform::VEC2}, {Shader::Uniform::VEC3}, {Shader::Uniform::VEC4}, {Shader::Uniform::INT}, {Shader::Uniform::IVEC2}, {Shader::Uniform::IVEC3}, or {Shader::Uniform::IVEC4}
+# @param variable_type [Integer] Valid options are {Shader::Uniform::FLOAT}, {Shader::Uniform::VEC2}, {Shader::Uniform::VEC3}, {Shader::Uniform::VEC4}, {Shader::Uniform::INT}, {Shader::Uniform::IVEC2}, {Shader::Uniform::IVEC3}, or {Shader::Uniform::IVEC4}.
 # @return [Integer]
 def set_shader_values(shader, variable_location, variables, variable_type)
   # mrb_set_shader_values

--- a/mrb_doc/text.rb
+++ b/mrb_doc/text.rb
@@ -1,3 +1,35 @@
+<<<<<<< HEAD
+=======
+# Loads a font from a file.
+# @param path [String]
+# @return [Font]
+def load_font(path)
+  # mrb_load_font
+  # src/mruby_integration/text.cpp
+  Font.new
+end
+
+# Loads a font from a file with extended options.
+# @param path [String]
+# @param font_size [Integer]
+# @param char_count [Integer]
+# @return [Font]
+def load_font_ex(path, font_size, char_count)
+  # mrb_load_font_ex
+  # src/mruby_integration/text.cpp
+  Font.new
+end
+
+# Unloads a font from memory.
+# @param font [Font]
+# @return [nil]
+def unload_font(font)
+  # mrb_unload_font
+  # src/mruby_integration/text.cpp
+  nil
+end
+
+>>>>>>> aea7c7f62eefa36f5930ba95057904e50b2036d4
 # Draws the current frame rate at the passed in x and y coordinates.
 # @param x [Integer]
 # @param y [Integer]
@@ -7,3 +39,45 @@ def draw_fps(x, y)
   # src/mruby_integration/text.cpp
   nil
 end
+<<<<<<< HEAD
+=======
+
+# Draws the current frame rate at the passed in x and y coordinates.
+# @param text [String] The text to put on the screen.
+# @param x [Integer]
+# @param y [Integer]
+# @param font_size [Integer]
+# @param colour [Colour]
+# @return [nil]
+def draw_text(text, x, y, font_size, colour)
+  # mrb_draw_text
+  # src/mruby_integration/text.cpp
+  nil
+end
+
+# Draws the text at the given position, size, padding, and colour with the specified font.
+# @param font [Font] Which font to draw with.
+# @param text [String] The text to put on the screen.
+# @param position [Vector2]
+# @param font_size [Integer]
+# @param font_padding [Integer]
+# @param colour [Colour]
+# @return [nil]
+def draw_text_ex(font, text, position, font_size, font_padding, colour)
+  # mrb_draw_text_ex
+  # src/mruby_integration/text.cpp
+  nil
+end
+
+# Returns the size of the text for the given font.
+# @param font [Font] Which font to draw with.
+# @param text [String] The text to put on the screen.
+# @param font_size [Integer]
+# @param font_padding [Integer]
+# @return [Vector2]
+def measure_text_ex(font, text, font_size, font_padding)
+  # mrb_measure_text_ex
+  # src/mruby_integration/text.cpp
+  Vector2.new(32, 12)
+end
+>>>>>>> aea7c7f62eefa36f5930ba95057904e50b2036d4

--- a/mrb_doc/textures.rb
+++ b/mrb_doc/textures.rb
@@ -1,4 +1,4 @@
-# Loads a texture from a file
+# Loads a texture from a file.
 # @param path [String]
 # @return [Texture2D]
 def load_texture(path)
@@ -7,7 +7,20 @@ def load_texture(path)
   Texture2D.new
 end
 
+<<<<<<< HEAD
 # Unloads a texture
+=======
+# Loads a texture from an image object.
+# @param image [Image]
+# @return [Texture2D]
+def load_texture_from_image(image)
+  # mrb_load_texture_from_image
+  # src/mruby_integration/textures.cpp
+  Texture2D.new
+end
+
+# Unloads a texture.
+>>>>>>> aea7c7f62eefa36f5930ba95057904e50b2036d4
 # @param texture [Texture2D]
 # @return [nil]
 def unload_texture(texture)
@@ -16,7 +29,7 @@ def unload_texture(texture)
   nil
 end
 
-# Draws a texture, the colour will apply a tint and alpha levels
+# Draws a texture, the colour will apply a tint and alpha levels.
 # @param texture [Texture2D]
 # @param x [Integer]
 # @param y [Integer]
@@ -28,8 +41,8 @@ def draw_texture(texture, x, y, colour)
   nil
 end
 
-# Draws a section of texture with the specified rotation to the scaled to the
-# destination rectangle, the colour will apply a tint and alpha levels
+# Draws a section of texture with the specified rotation scaled to the
+# destination rectangle, the colour will apply a tint and alpha levels.
 # @param texture [Texture2D]
 # @param source [Rectangle]
 # @param destination [Rectangle]
@@ -43,8 +56,8 @@ def draw_texture_pro(texture, source, destination, origin, rotation, colour)
   nil
 end
 
-# Returns a new colour which is a faded version of the original
-# @param colour [Colour
+# Returns a new colour which is a faded version of the original.
+# @param colour [Colour]
 # @return [Colour]
 def fade(colour)
   # mrb_fade
@@ -52,7 +65,7 @@ def fade(colour)
   Colour.new
 end
 
-# Generates mipmaps for the {Texture2D}
+# Generates mipmaps for the {Texture2D}.
 # @param texture [Texture2D]
 # @return [nil]
 def generate_texture_mipmaps(texture)
@@ -61,9 +74,9 @@ def generate_texture_mipmaps(texture)
   nil
 end
 
-# Sets the filtering for the {Texture2D}
+# Sets the filtering for the {Texture2D}.
 # @param texture [Texture2D]
-# @param filter [Integer] What sort of filtering to apply, valid options are: {TEXTURE_FILTER_POINT}, {TEXTURE_FILTER_BILINEAR}, {TEXTURE_FILTER_TRILINEAR}, {TEXTURE_FILTER_ANISOTROPIC_4X}, {TEXTURE_FILTER_ANISOTROPIC_8X}, or {TEXTURE_FILTER_ANISOTROPIC_16X}
+# @param filter [Integer] What sort of filtering to apply, valid options are: {TEXTURE_FILTER_POINT}, {TEXTURE_FILTER_BILINEAR}, {TEXTURE_FILTER_TRILINEAR}, {TEXTURE_FILTER_ANISOTROPIC_4X}, {TEXTURE_FILTER_ANISOTROPIC_8X}, or {TEXTURE_FILTER_ANISOTROPIC_16X}.
 # @return [nil]
 def set_texture_filter(texture, filter)
   # mrb_set_texture_filter

--- a/mrb_doc/web.rb
+++ b/mrb_doc/web.rb
@@ -1,7 +1,7 @@
-# Sets the main loop for web exports
+# Sets the main loop for web exports.
 # @param method [String]
 # @return [nil]
-# @raise [PlatformSpecificMethodCalledOnWrongPlatformError] If run on the wrong platform
+# @raise [PlatformSpecificMethodCalledOnWrongPlatformError] If run on the wrong platform.
 def set_main_loop(method)
   # mrb_set_main_loop
   # src/web.cpp


### PR DESCRIPTION
I've noticed that some documentation has missing periods while other hasn't, there are some typos here and there, and generally some other things that can be improved using some [YARD](https://yardoc.org/) features. So this PR aims to address that.

I didn't go ahead and check `models/`, `shapes/` and also `src/ruby/...` yet since I didn't want this PR to be that big & wanted to get some feedback from you :sweat_smile:

### Notable Changes

- Usage of the `@example` tag for code snippets instead of monospaced formatting. 
  Before:
  ![imagen](https://github.com/HellRok/Taylor/assets/83732118/48d2cbca-f88b-4ed6-8a2d-b940b1447b0b)
  After:
  ![imagen](https://github.com/HellRok/Taylor/assets/83732118/4076c096-73c4-447f-a77e-93258251ab57)
- Usage of braces to link classes in the docs instead of monospaced formatting.


