### PR TITLE
Fix Documentation Grammar 

### DIFF
--- a/mrb_doc/audio/device.rb
+++ b/mrb_doc/audio/device.rb
@@ -1,4 +1,4 @@
-# Initialises the audio device for playback
+# Initialises the audio device for playback.
 # @return [nil]
 def init_audio_device
   # mrb_init_audio_device
@@ -6,7 +6,7 @@ def init_audio_device
   nil
 end
 
-# Closes the audio device
+# Closes the audio device.
 # @return [nil]
 def close_audio_device
   # mrb_close_audio_device
@@ -14,7 +14,7 @@ def close_audio_device
   nil
 end
 
-# Returns if the audio device has been setup
+# Returns if the audio device has been setup.
 # @return [Boolean]
 def audio_device_ready?
   # mrb_audio_device_ready
@@ -22,8 +22,8 @@ def audio_device_ready?
   true
 end
 
-# Sets the master volume
-# @param volume [Float] a value between 0.0 and 1.0
+# Sets the master volume.
+# @param volume [Float] A value between 0.0 and 1.0.
 # @return [nil]
 def set_master_volume(volume)
   # mrb_set_master_volume

--- a/mrb_doc/audio/music.rb
+++ b/mrb_doc/audio/music.rb
@@ -1,4 +1,4 @@
-# Loads a music object from a file
+# Loads a music object from a file.
 # @param path [String]
 # @return [Music]
 def load_music_stream(path)
@@ -7,7 +7,7 @@ def load_music_stream(path)
   Music.new
 end
 
-# Unloads a music object
+# Unloads a music object.
 # @param music [Music]
 # @return [nil]
 def unload_music_stream(music)
@@ -16,7 +16,7 @@ def unload_music_stream(music)
   nil
 end
 
-# Starts playback of a music object from the beginning
+# Starts playback of a music object from the beginning.
 # @param music [Music]
 # @return [nil]
 def play_music_stream(music)
@@ -25,7 +25,7 @@ def play_music_stream(music)
   nil
 end
 
-# Checks whether or not a music object is currently playing
+# Checks whether or not a music object is currently playing.
 # @param music [Music]
 # @return [Boolean]
 def music_playing?(music)
@@ -34,7 +34,7 @@ def music_playing?(music)
   true
 end
 
-# Updates the buffer for the specified music, you should call this every frame
+# Updates the buffer for the specified music, you should call this every frame.
 # @param music [Music]
 # @return [nil]
 def update_music_stream(music)
@@ -43,7 +43,7 @@ def update_music_stream(music)
   nil
 end
 
-# Stops a music object from playing
+# Stops a music object from playing.
 # @param music [Music]
 # @return [nil]
 def stop_music_stream(music)
@@ -52,7 +52,7 @@ def stop_music_stream(music)
   nil
 end
 
-# Pauses a music object so it can be resumed
+# Pauses a music object so it can be resumed.
 # @param music [Music]
 # @return [nil]
 def pause_music_stream(music)
@@ -61,7 +61,7 @@ def pause_music_stream(music)
   nil
 end
 
-# Resumes a paused music object
+# Resumes a paused music object.
 # @param music [Music]
 # @return [nil]
 def resume_music_stream(music)
@@ -70,9 +70,9 @@ def resume_music_stream(music)
   nil
 end
 
-# Sets volume for a music object
+# Sets volume for a music object.
 # @param music [Music]
-# @param volume [Float] A value between 0.0 and 1.0
+# @param volume [Float] A value between 0.0 and 1.0.
 # @return [nil]
 def set_music_volume(music, volume)
   # mrb_set_music_volume
@@ -80,7 +80,7 @@ def set_music_volume(music, volume)
   nil
 end
 
-# Sets pitch for a music object
+# Sets pitch for a music object.
 # @param music [Music]
 # @param pitch [Float]
 # @return [nil]
@@ -90,18 +90,18 @@ def set_music_pitch(music, pitch)
   nil
 end
 
-# Gets the length of a music object in seconds
+# Gets the length of a music object in seconds.
 # @param music [Music]
-# @return [Float] The length of the music object is seconds
+# @return [Float] The length of the music object in seconds.
 def get_music_time_length(music)
   # mrb_get_music_time_length
   # src/mruby_integration/audio/music.cpp
   nil
 end
 
-# Gets the time played of a music object in seconds
+# Gets the time played of a music object in seconds.
 # @param music [Music]
-# @return [Float] The length of the music object is seconds
+# @return [Float] The length of the music object in seconds
 def get_music_time_played(music)
   # mrb_get_music_time_played
   # src/mruby_integration/audio/music.cpp

--- a/mrb_doc/audio/sound.rb
+++ b/mrb_doc/audio/sound.rb
@@ -1,4 +1,4 @@
-# Loads a sound object from a file
+# Loads a sound object from a file.
 # @param path [String]
 # @return [Sound]
 def load_sound(path)
@@ -7,7 +7,7 @@ def load_sound(path)
   Sound.new
 end
 
-# Unloads a sound object
+# Unloads a sound object.
 # @param sound [Sound]
 # @return [nil]
 def unload_sound(sound)
@@ -16,7 +16,7 @@ def unload_sound(sound)
   nil
 end
 
-# Plays a sound object
+# Plays a sound object.
 # @param sound [Sound]
 # @return [nil]
 def play_sound(sound)
@@ -25,7 +25,7 @@ def play_sound(sound)
   nil
 end
 
-# Stops a sound object
+# Stops a sound object.
 # @param sound [Sound]
 # @return [nil]
 def stop_sound(sound)
@@ -34,7 +34,7 @@ def stop_sound(sound)
   nil
 end
 
-# Pauses a sound object so it can be resumed
+# Pauses a sound object so it can be resumed.
 # @param sound [Sound]
 # @return [nil]
 def pause_sound(sound)
@@ -43,7 +43,7 @@ def pause_sound(sound)
   nil
 end
 
-# Resumes a paused sound object
+# Resumes a paused sound object.
 # @param sound [Sound]
 # @return [nil]
 def resume_sound(sound)
@@ -52,7 +52,7 @@ def resume_sound(sound)
   nil
 end
 
-# Checks whether or not a sound object is currently playing
+# Checks whether or not a sound object is currently playing.
 # @param sound [Sound]
 # @return [Boolean]
 def sound_playing?(sound)
@@ -61,9 +61,9 @@ def sound_playing?(sound)
   true
 end
 
-# Sets the volume of the sound object
+# Sets the volume of the sound object.
 # @param sound [Sound]
-# @param volume [Float] a value between 0.0 and 1.0
+# @param volume [Float] A value between 0.0 and 1.0.
 # @return [nil]
 def set_sound_volume(sound, volume)
   # mrb_set_sound_volume
@@ -71,7 +71,7 @@ def set_sound_volume(sound, volume)
   1
 end
 
-# Sets the pitch of the sound object
+# Sets the pitch of the sound object.
 # @param sound [Sound]
 # @param pitch [Float]
 # @return [nil]

--- a/mrb_doc/core/cursor.rb
+++ b/mrb_doc/core/cursor.rb
@@ -1,4 +1,4 @@
-# Shows the cursor
+# Shows the cursor.
 # @return [nil]
 def show_cursor
   # mrb_show_cursor
@@ -6,7 +6,7 @@ def show_cursor
   nil
 end
 
-# Hides the cursor
+# Hides the cursor.
 # @return [nil]
 def hide_cursor
   # mrb_hide_cursor
@@ -14,7 +14,7 @@ def hide_cursor
   nil
 end
 
-# Checks if the cursor is hidden
+# Checks if the cursor is hidden.
 # @return [Boolean]
 def cursor_hidden?
   # mrb_cursor_hidden
@@ -22,7 +22,7 @@ def cursor_hidden?
   true
 end
 
-# Enables and shows the cursor
+# Enables and shows the cursor.
 # @return [nil]
 def enable_cursor
   # mrb_enable_cursor
@@ -30,7 +30,7 @@ def enable_cursor
   nil
 end
 
-# Disables the cursor and hides it
+# Disables the cursor and hides it.
 # @return [nil]
 def disable_cursor
   # mrb_disable_cursor
@@ -38,7 +38,7 @@ def disable_cursor
   nil
 end
 
-# Checks if the cursor is in the window
+# Checks if the cursor is in the window.
 # @return [Boolean]
 def cursor_on_screen?
   # mrb_cursor_on_screen

--- a/mrb_doc/core/drawing.rb
+++ b/mrb_doc/core/drawing.rb
@@ -1,4 +1,4 @@
-# Clears the screen with the specified colour
+# Clears the screen with the specified colour.
 # @param colour [Colour]
 # @return [nil]
 def clear_background(colour)
@@ -7,7 +7,7 @@ def clear_background(colour)
   nil
 end
 
-# Starts drawing to the screen
+# Starts drawing to the screen.
 # @return [nil]
 def begin_drawing
   # mrb_begin_drawing
@@ -15,7 +15,7 @@ def begin_drawing
   nil
 end
 
-# Ends drawing to the screen
+# Ends drawing to the screen.
 # @return [nil]
 def end_drawing
   # mrb_end_drawing
@@ -23,7 +23,7 @@ def end_drawing
   nil
 end
 
-# Starts drawing to the RenderTexture
+# Starts drawing to the {RenderTexture}.
 # @param texture [RenderTexture]
 # @return [nil]
 def begin_texture_mode(texture)
@@ -32,7 +32,7 @@ def begin_texture_mode(texture)
   nil
 end
 
-# Stops drawing to the RenderTexture
+# Stops drawing to the {RenderTexture}.
 # @return [nil]
 def end_texture_mode
   # mrb_end_texture_mode
@@ -40,7 +40,7 @@ def end_texture_mode
   nil
 end
 
-# All draw calls within will be drawn through the Shader
+# All draw calls within will be drawn through the {Shader}.
 # @param shader [Shader]
 # @return [nil]
 def begin_shader_mode(shader)
@@ -49,7 +49,7 @@ def begin_shader_mode(shader)
   nil
 end
 
-# Stops drawing through the Shader
+# Stops drawing through the {Shader}.
 # @return [nil]
 def end_shader_mode
   # mrb_end_shader_mode
@@ -57,7 +57,7 @@ def end_shader_mode
   nil
 end
 
-# In scissor mode only draw calls within the defined area will actually be drawn
+# In scissor mode only draw calls within the defined area will actually be drawn.
 # @param x [Integer]
 # @param y [Integer]
 # @param width [Integer]
@@ -69,7 +69,7 @@ def begin_scissor_mode(x, y, width, height)
   nil
 end
 
-# End scissor mode
+# End scissor mode.
 # @return [nil]
 def end_scissor_mode
   # mrb_end_scissor_mode

--- a/mrb_doc/core/files.rb
+++ b/mrb_doc/core/files.rb
@@ -1,4 +1,4 @@
-# Have their been files dropped that haven't been dealt with?
+# Have there been files dropped that haven't been dealt with?
 # @return [nil]
 def files_dropped?
   # mrb_files_dropped

--- a/mrb_doc/core/gestures.rb
+++ b/mrb_doc/core/gestures.rb
@@ -1,5 +1,6 @@
-# Enable only specific gestures, to pass in multiple you can do so like:
-#   `set_gestures_enabled(GESTURE_TAP | GESTURE_SWIPE_UP)`
+# Enable only specific gestures.
+# @example Passing multiple flags.
+#   set_gestures_enabled(GESTURE_TAP | GESTURE_SWIPE_UP)
 # @param flags [Integer]
 # @return [nil]
 def set_gestures_enabled(flags)
@@ -8,7 +9,7 @@ def set_gestures_enabled(flags)
   nil
 end
 
-# Returns the detected gestures based on their constant
+# Returns the detected gestures based on their constant.
 # @return [Integer]
 def get_gesture_detected
   # mrb_get_gesture_detected

--- a/mrb_doc/core/gestures.rb
+++ b/mrb_doc/core/gestures.rb
@@ -1,5 +1,5 @@
 # Enable only specific gestures.
-# @example Passing multiple flags.
+# @example Passing multiple flags
 #   set_gestures_enabled(GESTURE_TAP | GESTURE_SWIPE_UP)
 # @param flags [Integer]
 # @return [nil]

--- a/mrb_doc/core/input/gamepad.rb
+++ b/mrb_doc/core/input/gamepad.rb
@@ -1,4 +1,4 @@
-# Return whether or not the specified gamepad is available
+# Return whether or not the specified gamepad is available.
 # @param index [Integer]
 # @return [Bool]
 def gamepad_available?(index)
@@ -7,7 +7,7 @@ def gamepad_available?(index)
   true
 end
 
-# Returns the specified gamepads name
+# Returns the specified gamepad's name.
 # @param index [Integer]
 # @return [String]
 def get_gamepad_name(index)
@@ -56,7 +56,7 @@ def gamepad_button_up?(index, button)
   true
 end
 
-# Returns the last pressed gamepad button
+# Returns the last pressed gamepad button.
 # @return [Integer]
 def get_gamepad_button_pressed
   # mrb_get_gamepad_button_pressed
@@ -64,7 +64,7 @@ def get_gamepad_button_pressed
   0
 end
 
-# Returns the count of axis for the specified gamepad
+# Returns the count of axis for the specified gamepad.
 # @param index [Integer]
 # @return [Integer]
 def get_gamepad_axis_count(index)
@@ -73,7 +73,7 @@ def get_gamepad_axis_count(index)
   2
 end
 
-# Returns the movement of the specified axis for the specified gamepad
+# Returns the movement of the specified axis for the specified gamepad.
 # @param index [Integer]
 # @param axis [Integer]
 # @return [Float] -1.0 to 1.0
@@ -84,7 +84,7 @@ def get_gamepad_axis_movement(index, axis)
 end
 
 # Setup gamepad mappings using the
-# [SDL_GameControllerDB](https://github.com/gabomdq/SDL_GameControllerDB) format
+# [SDL_GameControllerDB](https://github.com/gabomdq/SDL_GameControllerDB) format.
 # @param mappings [String]
 # @return [Integer]
 def set_gamepad_mappings(mappings)

--- a/mrb_doc/core/input/keyboard.rb
+++ b/mrb_doc/core/input/keyboard.rb
@@ -34,7 +34,7 @@ def key_up?(key)
   False
 end
 
-# Sets the key for should_window_close? to listen for
+# Sets the key that {window_should_close?} should listen for.
 # @param key [Integer]
 # @return [nil]
 def set_exit_key(key)
@@ -43,7 +43,7 @@ def set_exit_key(key)
   nil
 end
 
-# Returns the keycode for the pressed key, call it multiple times for queued keys
+# Returns the keycode for the pressed key, call it multiple times for queued keys.
 # @return [Integer]
 def get_key_pressed
   # mrb_get_key_pressed
@@ -51,7 +51,7 @@ def get_key_pressed
   64
 end
 
-# Returns the charcode for the pressed key, call it multiple times for queued keys
+# Returns the charcode for the pressed key, call it multiple times for queued keys.
 # @return [Integer]
 def get_char_pressed
   # mrb_getchar_pressed

--- a/mrb_doc/core/input/mouse.rb
+++ b/mrb_doc/core/input/mouse.rb
@@ -34,7 +34,7 @@ def mouse_button_up?(button)
   false
 end
 
-# Returns the current mouse x position in the window
+# Returns the current mouse x position in the window.
 # @return [Integer]
 def get_mouse_x
   # mrb_get_mouse_x
@@ -42,7 +42,7 @@ def get_mouse_x
   64
 end
 
-# Returns the current mouse y position in the window
+# Returns the current mouse y position in the window.
 # @return [Integer]
 def get_mouse_y
   # mrb_get_mouse_y
@@ -50,7 +50,7 @@ def get_mouse_y
   64
 end
 
-# Returns the current mouse position in the window
+# Returns the current mouse position in the window.
 # @return [Vector2]
 def get_mouse_position
   # mrb_get_mouse_position
@@ -58,7 +58,7 @@ def get_mouse_position
   Vector2.new
 end
 
-# Sets the position of the muose
+# Sets the position of the muose.
 # @param x [Integer]
 # @param y [Integer]
 # @return [nil]
@@ -68,7 +68,7 @@ def set_mouse_position(x, y)
   nil
 end
 
-# Sets the offset for all mouse position functions
+# Sets the offset for all mouse position functions.
 # @param x [Integer]
 # @param y [Integer]
 # @return [nil]
@@ -78,7 +78,7 @@ def set_mouse_offset(x, y)
   nil
 end
 
-# Sets the scaling for all mouse position functions
+# Sets the scaling for all mouse position functions.
 # @param x [Float]
 # @param y [Float]
 # @return [nil]
@@ -88,7 +88,7 @@ def set_mouse_scale(x, y)
   nil
 end
 
-# Returns the movement of the mouse wheel since last frame
+# Returns the movement of the mouse wheel since last frame.
 # @return [Float]
 def get_mouse_wheel_move
   # mrb_get_mouse_wheel_move
@@ -96,7 +96,7 @@ def get_mouse_wheel_move
   0.5
 end
 
-# Sets the mouse cursor
+# Sets the mouse cursor.
 # @param cursor [Integer]
 # @return [nil]
 def set_mouse_cursor(cursor)

--- a/mrb_doc/core/input/touch.rb
+++ b/mrb_doc/core/input/touch.rb
@@ -1,4 +1,4 @@
-# Get the position within the window of the specified touch
+# Get the position within the window of the specified touch.
 # @param index [Integer]
 # @return [Vector2]
 def get_touch_position(index)

--- a/mrb_doc/core/misc.rb
+++ b/mrb_doc/core/misc.rb
@@ -9,7 +9,7 @@ def take_screenshot(filename)
 end
 
 # Enable specific config flags.
-# @example Passing multiple flags.
+# @example Passing multiple flags
 #   set_config_flags(FLAG_WINDOW_TOPMOST | FLAG_WINDOW_RESIZABLE)
 # @param flags [Integer]
 # @return [nil]

--- a/mrb_doc/core/misc.rb
+++ b/mrb_doc/core/misc.rb
@@ -1,8 +1,6 @@
-# You'll want to call this function after you've called `end_drawing` or you'll
+# You'll want to call this function after you've called {end_drawing} or you'll
 # find that you don't get everything that you think you've drawn.
-#
-# The extension of `filename` will dictate how the screenshot is saved.
-# @param filename [String]
+# @param filename [String] The filename to save to. The extension will dictate how it is saved.
 # @return [nil]
 def take_screenshot(filename)
   # mrb_take_screenshot
@@ -10,8 +8,9 @@ def take_screenshot(filename)
   nil
 end
 
-# Enable specific config flags, to pass in multiple you can do so like:
-#   `set_config_flags(FLAG_WINDOW_TOPMOST | FLAG_WINDOW_RESIZABLE)`
+# Enable specific config flags.
+# @example Passing multiple flags.
+#   set_config_flags(FLAG_WINDOW_TOPMOST | FLAG_WINDOW_RESIZABLE)
 # @param flags [Integer]
 # @return [nil]
 def set_config_flags(flags)
@@ -20,8 +19,8 @@ def set_config_flags(flags)
   nil
 end
 
-# Sets the logging level
-# @param level [Integer] A value between 0 and 5
+# Sets the logging level.
+# @param level [Integer] A value between 0 and 5.
 # @return [nil]
 def set_trace_log_level(level)
   # mrb_set_trace_log_level
@@ -29,7 +28,7 @@ def set_trace_log_level(level)
   nil
 end
 
-# Opens the URL in the users browser
+# Opens the URL in the user's browser.
 # @param url [String]
 # @return [nil]
 def open_url(url)
@@ -38,7 +37,7 @@ def open_url(url)
   nil
 end
 
-# Sets the clipboard value
+# Sets the clipboard value.
 # @param text [String]
 # @return [nil]
 def set_clipboard_text(text)
@@ -47,7 +46,7 @@ def set_clipboard_text(text)
   nil
 end
 
-# Gets the clipboard value
+# Gets the clipboard value.
 # @return [String]
 def get_clipboard_text
   # mrb_get_clipboard_text

--- a/mrb_doc/core/timing.rb
+++ b/mrb_doc/core/timing.rb
@@ -1,4 +1,4 @@
-# Set the framerate you wish to target (usually 60, 120, or 144)
+# Set the framerate you wish to target (usually 60, 120, or 144).
 # @param target [Integer]
 # @return [nil]
 def set_target_fps(target)
@@ -7,7 +7,7 @@ def set_target_fps(target)
   nil
 end
 
-# Returns the current framerate as an integer
+# Returns the current framerate as an integer.
 # @return [Integer]
 def get_fps
   # mrb_get_fps
@@ -15,7 +15,7 @@ def get_fps
   60
 end
 
-# Returns the amount of time the last frame took in seconds
+# Returns the amount of time the last frame took in seconds.
 # @return [Float]
 def get_frame_time
   # mrb_frame_time
@@ -23,7 +23,7 @@ def get_frame_time
   0.01633
 end
 
-# Returns the amount of time the has passed since init_window was called
+# Returns the amount of time the has passed since {init_window} was called.
 # @return [Float]
 def get_time
   # mrb_time

--- a/mrb_doc/core/window.rb
+++ b/mrb_doc/core/window.rb
@@ -1,4 +1,4 @@
-# Initialises a window for rendering
+# Initialises a window for rendering.
 # @param width [Integer]
 # @param height [Integer]
 # @param title [String]
@@ -17,7 +17,7 @@ def window_should_close?
   false
 end
 
-# Close the open window
+# Close the open window.
 # @return [nil]
 def close_window
   # mrb_close_window
@@ -33,8 +33,9 @@ def window_ready?
   true
 end
 
-# Checks if the window has the state set, to pass in multiple you can do so like:
-#   `window_state?(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)`
+# Checks if the window has the state set
+# @ Passing multiple flags.
+#   window_state?(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [Boolean]
 def window_state?(flags)
@@ -43,8 +44,9 @@ def window_state?(flags)
   true
 end
 
-# Sets the specified states on the window, to pass in multiple you can do so like:
-#   `set_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)`
+# Sets the specified states on the window.
+# @example Passing multiple flags.
+#   set_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [nil]
 def set_window_state(flags)
@@ -53,7 +55,7 @@ def set_window_state(flags)
   nil
 end
 
-# Checks if the window has the FLAG_FULLSCREEN_MODE state set
+# Checks if the window has the {FLAG_FULLSCREEN_MODE} state set.
 # @return [Boolean]
 def window_fullscreen?
   # mrb_window_fullscreen
@@ -61,7 +63,7 @@ def window_fullscreen?
   true
 end
 
-# Checks if the window has the FLAG_WINDOW_HIDDEN state set
+# Checks if the window has the {FLAG_WINDOW_HIDDEN} state set.
 # @return [Boolean]
 def window_hidden?
   # mrb_window_hidden
@@ -69,7 +71,7 @@ def window_hidden?
   false
 end
 
-# Checks if the window has the FLAG_WINDOW_MINIMISED state set
+# Checks if the window has the {FLAG_WINDOW_MINIMISED} state set.
 # @return [Boolean]
 def window_minimised?
   # mrb_window_minimised
@@ -77,7 +79,7 @@ def window_minimised?
   false
 end
 
-# Checks if the window has the FLAG_WINDOW_MAXIMISED state set
+# Checks if the window has the {FLAG_WINDOW_MAXIMISED} state set.
 # @return [Boolean]
 def window_maximised?
   # mrb_window_maximised
@@ -85,7 +87,7 @@ def window_maximised?
   true
 end
 
-# Checks if the window has focus
+# Checks if the window has focus.
 # @return [Boolean]
 def window_focused?
   # mrb_window_focused
@@ -93,7 +95,7 @@ def window_focused?
   true
 end
 
-# Checks if the window was resized since the last frame
+# Checks if the window was resized since the last frame.
 # @return [Boolean]
 def window_resized?
   # mrb_window_resized
@@ -101,8 +103,9 @@ def window_resized?
   false
 end
 
-# Clears the specified states on the window, to pass in multiple you can do so like:
-#   `clear_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)`
+# Clears the specified states on the window.
+# @example Passing multiple flags.
+#   clear_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [nil]
 def clear_window_state(flags)
@@ -111,7 +114,7 @@ def clear_window_state(flags)
   nil
 end
 
-# Toggles the fullscreen state
+# Toggles the fullscreen state.
 # @return [nil]
 def toggle_fullscreen
   # mrb_toggle_fullscreen
@@ -119,7 +122,7 @@ def toggle_fullscreen
   nil
 end
 
-# Maximises the window
+# Maximises the window.
 # @return [nil]
 def maximise_window
   # mrb_maximise_window
@@ -127,7 +130,7 @@ def maximise_window
   nil
 end
 
-# Minimises the window
+# Minimises the window.
 # @return [nil]
 def minimise_window
   # mrb_minimise_window
@@ -135,8 +138,8 @@ def minimise_window
   nil
 end
 
-# Restores the window from being maximised or minimised
-# @note I don't think it currently works for restoring from minimised
+# Restores the window from being maximised or minimised.
+# @note I don't think it currently works for restoring from minimised.
 # @return [nil]
 def restore_window
   # mrb_restore_window
@@ -144,7 +147,7 @@ def restore_window
   nil
 end
 
-# Sets the icon for the current window
+# Sets the icon for the current window.
 # @param image [Image]
 # @return [nil]
 def set_window_icon(image)
@@ -153,7 +156,7 @@ def set_window_icon(image)
   nil
 end
 
-# Sets the title for the current window
+# Sets the title for the current window.
 # @param title [String]
 # @return [nil]
 def set_window_title(title)
@@ -162,7 +165,7 @@ def set_window_title(title)
   nil
 end
 
-# Sets the position for the current window
+# Sets the position for the current window.
 # @param x [Integer]
 # @param y [Integer]
 # @return [nil]
@@ -172,7 +175,7 @@ def set_window_position(x, y)
   nil
 end
 
-# Sets the monitor for the current window
+# Sets the monitor for the current window.
 # @param monitor [Integer]
 # @return [nil]
 def set_window_monitor(monitor)
@@ -181,7 +184,7 @@ def set_window_monitor(monitor)
   nil
 end
 
-# Sets the minimum allowed size for the current window
+# Sets the minimum allowed size for the current window.
 # @param width [Integer]
 # @param height [Integer]
 # @return [nil]
@@ -190,8 +193,8 @@ def set_window_min_size(width, height)
   # src/mruby_integration/core/window.cpp
   nil
 end
-
-# Sets the size for the current window
+  
+# Sets the size for the current window.
 # @param width [Integer]
 # @param height [Integer]
 # @return [nil]
@@ -201,7 +204,7 @@ def set_window_size(width, height)
   nil
 end
 
-# Gets the width of the window
+# Gets the width of the window.
 # @return [Integer]
 def get_screen_width
   # mrb_get_screen_width
@@ -209,7 +212,7 @@ def get_screen_width
   640
 end
 
-# Gets the height of the window
+# Gets the height of the window.
 # @return [Integer]
 def get_screen_height
   # mrb_get_screen_height
@@ -217,7 +220,7 @@ def get_screen_height
   480
 end
 
-# Gets the total number of monitors the user has
+# Gets the total number of monitors the user has.
 # @return [Integer]
 def get_monitor_count
   # mrb_get_monitor_count
@@ -225,7 +228,7 @@ def get_monitor_count
   2
 end
 
-# Gets the id of the current monitor
+# Gets the id of the current monitor.
 # @return [Integer]
 def get_current_monitor
   # mrb_get_current_monitor
@@ -233,7 +236,7 @@ def get_current_monitor
   0
 end
 
-# Gets the position of the specified monitor
+# Gets the position of the specified monitor.
 # @param monitor [Integer]
 # @return [Vector2]
 def get_monitor_position(monitor)
@@ -242,7 +245,7 @@ def get_monitor_position(monitor)
   Vector2.new(0, 0)
 end
 
-# Gets the width of the specified monitor
+# Gets the width of the specified monitor.
 # @param monitor [Integer]
 # @return [Integer]
 def get_monitor_width(monitor)
@@ -251,7 +254,7 @@ def get_monitor_width(monitor)
   1920
 end
 
-# Gets the height of the specified monitor
+# Gets the height of the specified monitor.
 # @param monitor [Integer]
 # @return [Integer]
 def get_monitor_height(monitor)
@@ -260,7 +263,7 @@ def get_monitor_height(monitor)
   1080
 end
 
-# Gets the refresh rate of the specified monitor
+# Gets the refresh rate of the specified monitor.
 # @param monitor [Integer]
 # @return [Integer]
 def get_monitor_refresh_rate(monitor)
@@ -269,7 +272,7 @@ def get_monitor_refresh_rate(monitor)
   60
 end
 
-# Gets the position of the window
+# Gets the position of the window.
 # @return [Vector2]
 def get_window_position
   # mrb_get_window_position
@@ -277,7 +280,7 @@ def get_window_position
   Vector2.new(10, 10)
 end
 
-# Gets the scale of the window
+# Gets the scale of the window.
 # @return [Vector2]
 def get_window_scale_dpi
   # mrb_get_window_scale_dpi

--- a/mrb_doc/core/window.rb
+++ b/mrb_doc/core/window.rb
@@ -34,7 +34,7 @@ def window_ready?
 end
 
 # Checks if the window has the state set
-# @ Passing multiple flags.
+# @ Passing multiple flags
 #   window_state?(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [Boolean]
@@ -45,7 +45,7 @@ def window_state?(flags)
 end
 
 # Sets the specified states on the window.
-# @example Passing multiple flags.
+# @example Passing multiple flags
 #   set_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [nil]
@@ -104,7 +104,7 @@ def window_resized?
 end
 
 # Clears the specified states on the window.
-# @example Passing multiple flags.
+# @example Passing multiple flags
 #   clear_window_state(FLAG_WINDOW_ALWAYS_RUN | FLAG_WINDOW_HIDDEN)
 # @param flags [Integer]
 # @return [nil]

--- a/mrb_doc/image.rb
+++ b/mrb_doc/image.rb
@@ -1,4 +1,4 @@
-# Inverts the colours of the image
+# Inverts the colours of the image.
 # @param image [Image]
 # @return [nil]
 def image_colour_invert!(image)
@@ -7,7 +7,7 @@ def image_colour_invert!(image)
   nil
 end
 
-# Converts the image to grayscale
+# Converts the image to grayscale.
 # @param image [Image]
 # @return [nil]
 def image_colour_grayscale!(image)
@@ -16,9 +16,9 @@ def image_colour_grayscale!(image)
   nil
 end
 
-# Change the contrast of the image
+# Change the contrast of the image.
 # @param image [Image]
-# @param contrast [Float] a value between -100 and 100
+# @param contrast [Float] A value between -100 and 100.
 # @return [nil]
 def image_colour_contrast!(image, contrast)
   # mrb_image_colour_contrast
@@ -26,9 +26,9 @@ def image_colour_contrast!(image, contrast)
   nil
 end
 
-# Change the brightness of the image
+# Change the brightness of the image.
 # @param image [Image]
-# @param brightness [Float] a value between -255 and 255
+# @param brightness [Float] A value between -255 and 255.
 # @return [nil]
 def image_colour_brightness!(image, brightness)
   # mrb_image_colour_brightness
@@ -36,7 +36,7 @@ def image_colour_brightness!(image, brightness)
   nil
 end
 
-# Replace the old Colour with the new Colour
+# Replace the old Colour with the new Colour.
 # @param image [Image]
 # @param old_colour [Colour]
 # @param new_colour [Colour]
@@ -61,7 +61,7 @@ def image_draw!(destination, source, source_rectangle, destination_rectangle, co
   nil
 end
 
-# Returns an Image object with the screen data
+# Returns an Image object with the screen data.
 # @return [Image]
 def get_screen_data
   # mrb_get_screen_data

--- a/mrb_doc/models/camera2d.rb
+++ b/mrb_doc/models/camera2d.rb
@@ -1,16 +1,15 @@
 class Camera2D
   # Creates a new instance of {Camera2D}.
   #
-  # ```ruby
-  # player = Vector2[400, 240]
+  # @example Basic usage.
+  #   player = Vector2[400, 240]
   #
-  # camera = Camera2D.new(offset: player)
+  #   camera = Camera2D.new(offset: player)
   #
-  # player.x = 200
-  # player.y = 120
+  #   player.x = 200
+  #   player.y = 120
   #
-  # camera.offset = player
-  # ```
+  #   camera.offset = player
   #
   # @param offset [Vector2]
   # @param target [Vector2]
@@ -34,18 +33,16 @@ class Camera2D
   end
 
   # Draws the world through the lens of the {Camera2D}.
-  # rectangle = Rectangle.new(2, 2, 6, 6)
   #
-  # ```ruby
-  # rectangle = Rectangle[100, 100, 50, 50]
-  # camera = Camera2D.new(offset: Vector2[100, 150])
+  # @example Basic usage.
+  #   rectangle = Rectangle[100, 100, 50, 50]
+  #   camera = Camera2D.new(offset: Vector2[100, 150])
   #
-  # camera.draw do
-  #     rectangle.draw(colour: RED)
-  # end
-  # ```
+  #   camera.draw do
+  #       rectangle.draw(colour: RED)
+  #   end
   #
-  # @yield The block that calls your rendering logic
+  # @yield The block that calls your rendering logic.
   # @return [nil]
   def draw(&block)
     # mrb_Camera2D_set_zoom
@@ -56,16 +53,13 @@ class Camera2D
   # Pass in a vector with world coordinates to see what that translates to in
   # the camera's viewport.
   #
-  # ```ruby
-  #  camera = Camera2D.new(target: Vector2[2, 1], offset: Vector2[3, 2])
-  #  vector = Vector2[3, 3]
+  # @example Basic usage.
+  #   camera = Camera2D.new(target: Vector2[2, 1], offset: Vector2[3, 2])
+  #   vector = Vector2[3, 3]
   #
-  #  translated_vector = camera.as_in_viewport(vector)
-  #  puts translated_vector.x
-  #  # => 4
-  #  puts translated_vector.y
-  #  # => 4
-  # ```
+  #   translated_vector = camera.as_in_viewport(vector)
+  #   puts translated_vector.x # => 4
+  #   puts translated_vector.y # => 4
   #
   # @param vector [Vector2]
   # @return [Vector2]
@@ -78,16 +72,13 @@ class Camera2D
   # Pass in a vector with screen coordinates to see what that translates to in
   # the world from camera's viewport.
   #
-  # ```ruby
-  #  camera = Camera2D.new(target: Vector2[2, 1], offset: Vector2[3, 2])
-  #  vector = Vector2[4, 4]
+  # @example Basic usage.
+  #   camera = Camera2D.new(target: Vector2[2, 1], offset: Vector2[3, 2])
+  #   vector = Vector2[4, 4]
   #
-  #  translated_vector = camera.as_in_world(vector)
-  #  puts translated_vector.x
-  #  # => 3
-  #  puts translated_vector.y
-  #  # => 3
-  # ```
+  #   translated_vector = camera.as_in_world(vector)
+  #   puts translated_vector.x # => 3
+  #   puts translated_vector.y # => 3
   #
   # @param vector [Vector2]
   # @return [Vector2]

--- a/mrb_doc/models/camera2d.rb
+++ b/mrb_doc/models/camera2d.rb
@@ -1,7 +1,7 @@
 class Camera2D
   # Creates a new instance of {Camera2D}.
   #
-  # @example Basic usage.
+  # @example Basic usage
   #   player = Vector2[400, 240]
   #
   #   camera = Camera2D.new(offset: player)
@@ -34,7 +34,7 @@ class Camera2D
 
   # Draws the world through the lens of the {Camera2D}.
   #
-  # @example Basic usage.
+  # @example Basic usage
   #   rectangle = Rectangle[100, 100, 50, 50]
   #   camera = Camera2D.new(offset: Vector2[100, 150])
   #
@@ -53,7 +53,7 @@ class Camera2D
   # Pass in a vector with world coordinates to see what that translates to in
   # the camera's viewport.
   #
-  # @example Basic usage.
+  # @example Basic usage
   #   camera = Camera2D.new(target: Vector2[2, 1], offset: Vector2[3, 2])
   #   vector = Vector2[3, 3]
   #
@@ -72,7 +72,7 @@ class Camera2D
   # Pass in a vector with screen coordinates to see what that translates to in
   # the world from camera's viewport.
   #
-  # @example Basic usage.
+  # @example Basic usage
   #   camera = Camera2D.new(target: Vector2[2, 1], offset: Vector2[3, 2])
   #   vector = Vector2[4, 4]
   #

--- a/mrb_doc/models/colour.rb
+++ b/mrb_doc/models/colour.rb
@@ -1,9 +1,9 @@
 class Colour
-  # Creates a new instance of Colour
-  # @param red [Integer] a value between 0 and 255
-  # @param blue [Integer] a value between 0 and 255
-  # @param green [Integer] a value between 0 and 255
-  # @param alpha [Integer] a value between 0 and 255
+  # Creates a new instance of Colour.
+  # @param red [Integer] A value between 0 and 255
+  # @param blue [Integer] A value between 0 and 255.
+  # @param green [Integer] A value between 0 and 255.
+  # @param alpha [Integer] A value between 0 and 255.
   # @return [Colour]
   def initialize(red, green, blue, alpha)
     # mrb_Colour_initialize

--- a/mrb_doc/models/font.rb
+++ b/mrb_doc/models/font.rb
@@ -1,7 +1,7 @@
 class Font
   # Returns the default built in {Font}. You may not want to {unload} this one!
   #
-  # @exmaple Using the default font.
+  # @example Using the default font
   #   Font.default.draw("Hello!")
   #
   # @return [Font]

--- a/mrb_doc/models/font.rb
+++ b/mrb_doc/models/font.rb
@@ -16,7 +16,7 @@ class Font
   #
   # Currently only TTF files are supported.
   #
-  # @example Basic usage.
+  # @example Basic usage
   #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #
   # @param path [String]
@@ -32,7 +32,7 @@ class Font
 
   # Draw the text to the screen using the loaded {Font}.
   #
-  # @example Drawing text on screen using a custom font.
+  # @example Drawing text on screen using a custom font
   #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   # 
   #   font.draw("Hello", x: 15, y: 12, colour: Colour::BLUE)
@@ -58,7 +58,7 @@ class Font
 
   # Returns the measurements of the text if drawn by the {Font}.
   #
-  # @example Measuring a string.
+  # @example Measuring a string
   #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #
   #   hello_size = font.measure("Hello")
@@ -80,7 +80,7 @@ class Font
 
   # Unloads the {Font} from memory.
   #
-  # @example Basic usage.
+  # @example Basic usage
   #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #   font.unload
   #
@@ -101,7 +101,7 @@ class Font
 
   # Creates an {Image} of the text using the {Font}.
   #
-  # @example Creating an image from the string "Hello".
+  # @example Creating an image from the string "Hello"
   #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #
   #   image = font.to_image("Hello", colour: Colour::PINK)

--- a/mrb_doc/models/font.rb
+++ b/mrb_doc/models/font.rb
@@ -1,9 +1,8 @@
 class Font
-  # Returns the default built in {Font}. You may not want to `unload` this one!
+  # Returns the default built in {Font}. You may not want to {unload} this one!
   #
-  # ```ruby
-  # Font.default.draw("Hello!")
-  # ```
+  # @exmaple Using the default font.
+  #   Font.default.draw("Hello!")
   #
   # @return [Font]
   def self.default
@@ -12,14 +11,13 @@ class Font
     Font.new
   end
 
-  # Loads a font file off of the disk. If the file does not exist, it will
+  # Loads a font file from the disk. If the file does not exist, it will
   # raise a {Font::NotFound} error.
   #
-  # Currently only ttf files are supported.
+  # Currently only TTF files are supported.
   #
-  # ```ruby
-  # font = Font.new("/assets/my_cool_font.ttf", size: 16)
-  # ```
+  # @example Basic usage.
+  #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #
   # @param path [String]
   # @param size [Integer]
@@ -34,20 +32,19 @@ class Font
 
   # Draw the text to the screen using the loaded {Font}.
   #
-  # ```ruby
-  # font = Font.new("/assets/my_cool_font.ttf", size: 16)
+  # @example Drawing text on screen using a custom font.
+  #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
+  # 
+  #   font.draw("Hello", x: 15, y: 12, colour: Colour::BLUE)
   #
-  # font.draw("Hello", x: 15, y: 12, colour: Colour::BLUE)
+  #   position = Vector[80, 90]
+  #   font.draw("Hello", position: position, colour: Colour::BLUE)
   #
-  # position = Vector[80, 90]
-  # font.draw("Hello", position: position, colour: Colour::BLUE)
+  #   font.unload
   #
-  # font.unload
-  # ```
-  #
-  # @param text [String] The text to draw on the screen
+  # @param text [String] The text to draw on the screen.
   # @param size [Float]
-  # @param spacing [Float] How much spacing to have between letters
+  # @param spacing [Float] How much spacing to have between letters.
   # @param x [Float]
   # @param y [Float]
   # @param position [Vector2]
@@ -61,23 +58,19 @@ class Font
 
   # Returns the measurements of the text if drawn by the {Font}.
   #
-  # ```ruby
-  # font = Font.new("/assets/my_cool_font.ttf", size: 16)
+  # @example Measuring a string.
+  #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #
-  # hello_size = font.measure("Hello")
+  #   hello_size = font.measure("Hello")
   #
-  # puts hello_size.width
-  # # => 33
+  #   puts hello_size.width # => 33
+  #   puts hello_size.height # => 16
   #
-  # puts hello_size.height
-  # # => 16
+  #   font.unload
   #
-  # font.unload
-  # ```
-  #
-  # @param text [String] The text to draw on the screen
+  # @param text [String] The text to measure.
   # @param size [Float]
-  # @param spacing [Float] How much spacing to have between letters
+  # @param spacing [Float] How much spacing to have between letters.
   # @return [Vector2]
   def measure(text, size: self.size, spacing: 0)
     # mrb_Font_measure
@@ -87,10 +80,9 @@ class Font
 
   # Unloads the {Font} from memory.
   #
-  # ```ruby
-  # font = Font.new("/assets/my_cool_font.ttf", size: 16)
-  # font.unload
-  # ```
+  # @example Basic usage.
+  #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
+  #   font.unload
   #
   # @return [nil]
   def unload
@@ -99,7 +91,7 @@ class Font
     nil
   end
 
-  # Checks if the font is loaded and ready to go
+  # Checks if the font is loaded and ready to go.
   # @return [Boolean]
   def ready?
     # mrb_Font_ready
@@ -109,18 +101,17 @@ class Font
 
   # Creates an {Image} of the text using the {Font}.
   #
-  # ```ruby
-  # font = Font.new("/assets/my_cool_font.ttf", size: 16)
+  # @example Creating an image from the string "Hello".
+  #   font = Font.new("/assets/my_cool_font.ttf", size: 16)
   #
-  # image = font.to_image("Hello", colour: Colour::PINK)
+  #   image = font.to_image("Hello", colour: Colour::PINK)
   #
-  # image.export("my_cool_text.jpg")
+  #   image.export("my_cool_text.jpg")
   #
-  # font.unload
-  # image.unload
-  # ```
+  #   font.unload
+  #   image.unload
   #
-  # @param text [String] The text to turn into an {Image}
+  # @param text [String] The text to turn into an {Image}.
   # @param size [Integer]
   # @param spacing [Integer]
   # @param colour [Colour]

--- a/mrb_doc/models/image.rb
+++ b/mrb_doc/models/image.rb
@@ -14,10 +14,10 @@ class Image
     Image.new
   end
 
-  # Loads an image file off of the disk. If the file does not exist, it will
+  # Loads an image file from the disk. If the file does not exist, it will
   # raise an {Image::NotFound} error.
   #
-  # Supported image types are png, jpg, bmp, qoi, gif, dds, hdr.
+  # Supported image formats are: PNG, JPG, BMP, QOI, GIF, DDS and HDR.
   #
   # @example Basic usage
   #   image = Image.new("/assets/image.png")
@@ -58,8 +58,7 @@ class Image
     nil
   end
 
-  # Copies the image to a new object. If `source` is specified it'll only be
-  # that section of the image that is returned.
+  # Copies the image to a new object. 
   #
   # @example Basic usage
   #   image = Image.new("./assets/my_cool_image.png")
@@ -70,7 +69,7 @@ class Image
   #   # This will only copy the portion x from 10 to 110, and y from 20 to 70
   #   subsection = image.copy(source: Rectangle[10, 20, 100, 50])
   #
-  # @param source [Rectangle]
+  # @param source [Rectangle] If specified, only this section of the image will be copied.
   # @return [Image]
   def copy(source: Rectangle[0, 0, width, height])
     # mrb_Image_copy
@@ -81,34 +80,29 @@ class Image
   # Resizes the image using one of the two scalers.
   #
   # `:nearest_neighbour` is useful for scaling up pixel art and works best in
-  # exact integer scaling.
+  # exact integer scaling. And `:bicubic` is useful for scaling up normal 
+  # images and works well at any scaling.
   #
-  # @example Basic usage
+  # @example Scaling an image using the nearest-neighbour scaler.
   #   image = Image.new("./assets/pixel_art.png")
-  #   p [image.width, image.height]
-  #   # => [8, 8]
+  #   p [image.width, image.height] # => [8, 8]
   #
+  #   # Nearest-neighbour is the default so no need to specify
   #   image.resize!(width: 16, height: 16)
-  #   p [image.width, image.height]
-  #   # => [16, 16]
+  #   p [image.width, image.height] # => [16, 16]
   #
-  # `:bicubic` is useful for scaling up normal images and works well at any
-  # scaling.
-  #
-  # @example Basic usage
+  # @example Scaling an image using the bicubic scaler.
   #   image = Image.new("./assets/background.png")
-  #   p [image.width, image.height]
-  #   # => [1280, 720]
+  #   p [image.width, image.height] # => [1280, 720]
   #
   #   image.resize!(width: 1920, height: 1080, scaler: :bicubic)
-  #   p [image.width, image.height]
-  #   # => [1920, 1080]
+  #   p [image.width, image.height] # => [1920, 1080]
   #
   # @param width [Integer]
   # @param height [Integer]
-  # @param scaler [Symbol] Valid options are :nearest_neighbour and :bicubic
+  # @param scaler [:nearest_neighbour, :bicubic]
   # @return [Image]
-  # @raise [ArgumentError] When passed an invalid scaler
+  # @raise [ArgumentError] When passed an invalid scaler.
   def resize!(width:, height:, scaler: :nearest_neighbour)
     # mrb_Image_resize_bang
     # src/mruby_integration/models/image.cpp
@@ -119,12 +113,10 @@ class Image
   #
   # @example Basic usage
   #   image = Image.new("./assets/spritesheet.png")
-  #   p [image.width, image.height]
-  #   # => [64, 128]
+  #   p [image.width, image.height] # => [64, 128]
   #
   #   image.crop!(source: Rectangle[8, 16, 8, 8])
-  #   p [image.width, image.height]
-  #   # => [8, 8]
+  #   p [image.width, image.height] # => [8, 8]
   #
   # @param source [Rectangle]
   # @return [Image]
@@ -202,7 +194,7 @@ class Image
   end
 
   # Premultiplies the alpha into the colour values. Useful for after you've
-  # applied an aplha mask.
+  # applied an alpha mask.
   #
   # @example Basic usage
   #   sprite = Image.new("./assets/sprite.png")
@@ -228,14 +220,11 @@ class Image
   # @example Basic usage
   #   sprite = Image.new("./assets/sprite.png")
   #
-  #   puts sprite.mipmaps
-  #   # => 1
+  #   puts sprite.mipmaps # => 1
   #
-  #   p [sprite.width, sprite.height]
-  #   # => [16, 16]
+  #   p [sprite.width, sprite.height] # => [16, 16]
   #
-  #   puts sprite.mipmaps
-  #   # => 5
+  #   puts sprite.mipmaps # => 5
   #
   # @return [Image]
   def generate_mipmaps!
@@ -258,7 +247,7 @@ class Image
     self
   end
 
-  # Returns an array containing the image data as an array of Colour objects.
+  # Returns an array containing the image data as an array of {Colour} objects.
   #
   # @return [Array<Colour>]
   def data

--- a/mrb_doc/models/image.rb
+++ b/mrb_doc/models/image.rb
@@ -83,7 +83,7 @@ class Image
   # exact integer scaling. And `:bicubic` is useful for scaling up normal 
   # images and works well at any scaling.
   #
-  # @example Scaling an image using the nearest-neighbour scaler.
+  # @example Scaling an image using the nearest-neighbour scaler
   #   image = Image.new("./assets/pixel_art.png")
   #   p [image.width, image.height] # => [8, 8]
   #
@@ -91,7 +91,7 @@ class Image
   #   image.resize!(width: 16, height: 16)
   #   p [image.width, image.height] # => [16, 16]
   #
-  # @example Scaling an image using the bicubic scaler.
+  # @example Scaling an image using the bicubic scaler
   #   image = Image.new("./assets/background.png")
   #   p [image.width, image.height] # => [1280, 720]
   #

--- a/mrb_doc/models/music.rb
+++ b/mrb_doc/models/music.rb
@@ -1,6 +1,6 @@
 class Music
-  # Creates a new instance of Music
-  # @param context_type [Integer] A value between 0 and 6
+  # Creates a new instance of Music.
+  # @param context_type [Integer] A value between 0 and 6.
   # @param looping [Boolean]
   # @param frame_count [Integer]
   # @return [Music]

--- a/mrb_doc/models/rectangle.rb
+++ b/mrb_doc/models/rectangle.rb
@@ -1,5 +1,5 @@
 class Rectangle
-  # Creates a new instance of Rectangle
+  # Creates a new instance of {Rectangle}.
   # @param x [Integer]
   # @param y [Integer]
   # @param width [Integer]

--- a/mrb_doc/models/render_texture.rb
+++ b/mrb_doc/models/render_texture.rb
@@ -1,5 +1,5 @@
 class RenderTexture
-  # Creates a new instance of RenderTexture
+  # Creates a new instance of {RenderTexture}.
   # @param width [Integer]
   # @param height [Integer]
   # @return [RenderTexture]
@@ -9,7 +9,7 @@ class RenderTexture
     RenderTexture.new
   end
 
-  # Unloads the render texture from memory
+  # Unloads the render texture from memory.
   # @return [nil]
   def unload
     # src/mruby_integration/models/render_texture.cpp

--- a/mrb_doc/models/shader.rb
+++ b/mrb_doc/models/shader.rb
@@ -1,5 +1,5 @@
 class Shader
-  # Creates a new instance of Shader
+  # Creates a new instance of {Shader}.
   # @param id [Integer]
   # @return [Shader]
   def initialize(id)

--- a/mrb_doc/models/sound.rb
+++ b/mrb_doc/models/sound.rb
@@ -1,5 +1,5 @@
 class Sound
-  # Creates a new instance of Sound
+  # Creates a new instance of {Sound}.
   # @param frame_count [Integer]
   # @return [Sound]
   def initialize(frame_count)

--- a/mrb_doc/models/texture2d.rb
+++ b/mrb_doc/models/texture2d.rb
@@ -1,5 +1,5 @@
 class Texture2D
-  # Creates a new instance of Texture2D
+  # Creates a new instance of {Texture2D}.
   # @param id [Integer]
   # @param width [Integer]
   # @param height [Integer]

--- a/mrb_doc/models/vector2.rb
+++ b/mrb_doc/models/vector2.rb
@@ -1,5 +1,5 @@
 class Vector2
-  # Creates a new instance of Vector2
+  # Creates a new instance of {Vector2}.
   # @param x [Float]
   # @param y [Float]
   # @return [Vector2]

--- a/mrb_doc/shaders.rb
+++ b/mrb_doc/shaders.rb
@@ -1,4 +1,4 @@
-# Loads a shader from in memory strings
+# Loads a shader from in-memory strings.
 # @param vertex_shader_code [String]
 # @param fragment_shader_code [String]
 # @return [Shader]
@@ -8,7 +8,7 @@ def load_shader_from_string(vertex_shader_code, fragment_shader_code)
   Shader.new
 end
 
-# Loads a shader from a file
+# Loads a shader from a file.
 # @param vertex_shader_path [String]
 # @param fragment_shader_path [String]
 # @return [Shader]
@@ -18,7 +18,7 @@ def load_shader(vertex_shader_path, fragment_shader_path)
   Shader.new
 end
 
-# Unloads a shader
+# Unloads a shader.
 # @param shader [Shader]
 # @return [nil]
 def unload_shader(shader)
@@ -27,7 +27,7 @@ def unload_shader(shader)
   nil
 end
 
-# Checks if the shader is ready
+# Checks if the shader is ready.
 # @param shader [Shader]
 # @return [Boolean]
 def shader_ready?(shader)
@@ -48,9 +48,9 @@ end
 
 # Returns the location of uniform variable, will return -1 if not found.
 # @param shader [Shader]
-# @param variable_location [Integer] The value you got from {get_shader_location}
+# @param variable_location [Integer] The value you got from {get_shader_location}.
 # @param variables [Array]
-# @param variable_type [Integer] Valid options are {Shader::Uniform::FLOAT}, {Shader::Uniform::VEC2}, {Shader::Uniform::VEC3}, {Shader::Uniform::VEC4}, {Shader::Uniform::INT}, {Shader::Uniform::IVEC2}, {Shader::Uniform::IVEC3}, or {Shader::Uniform::IVEC4}
+# @param variable_type [Integer] Valid options are {Shader::Uniform::FLOAT}, {Shader::Uniform::VEC2}, {Shader::Uniform::VEC3}, {Shader::Uniform::VEC4}, {Shader::Uniform::INT}, {Shader::Uniform::IVEC2}, {Shader::Uniform::IVEC3}, or {Shader::Uniform::IVEC4}.
 # @return [Integer]
 def set_shader_values(shader, variable_location, variables, variable_type)
   # mrb_set_shader_values

--- a/mrb_doc/shaders.rb
+++ b/mrb_doc/shaders.rb
@@ -50,7 +50,7 @@ end
 # @param shader [Shader]
 # @param variable_location [Integer] The value you got from {get_shader_location}.
 # @param variables [Array]
-# @param variable_type [Integer] Valid options are {Shader::Uniform::FLOAT}, {Shader::Uniform::VEC2}, {Shader::Uniform::VEC3}, {Shader::Uniform::VEC4}, {Shader::Uniform::INT}, {Shader::Uniform::IVEC2}, {Shader::Uniform::IVEC3}, or {Shader::Uniform::IVEC4}.
+# @param variable_type [Integer] Valid options are {Shader::Uniform::FLOAT}, {Shader::Uniform::VEC2}, {Shader::Uniform::VEC3}, {Shader::Uniform::VEC4}, {Shader::Uniform::INT}, {Shader::Uniform::IVEC2}, {Shader::Uniform::IVEC3} or {Shader::Uniform::IVEC4}.
 # @return [Integer]
 def set_shader_values(shader, variable_location, variables, variable_type)
   # mrb_set_shader_values

--- a/mrb_doc/shapes/circle.rb
+++ b/mrb_doc/shapes/circle.rb
@@ -1,4 +1,4 @@
-# Draw a circle
+# Draw a circle.
 # @param x [Integer]
 # @param y [Integer]
 # @param radius [Float]
@@ -10,7 +10,7 @@ def draw_circle(x, y, radius, colour)
   nil
 end
 
-# Draw a circle
+# Draw a circle.
 # @param vector [Vector2]
 # @param radius [Float]
 # @param colour [Colour]
@@ -21,12 +21,12 @@ def draw_circle_v(vector, radius, colour)
   nil
 end
 
-# Draw a circle sector
+# Draw a circle sector.
 # @param vector [Vector2]
 # @param radius [Float]
 # @param start_angle [Float]
 # @param end_angle [Float]
-# @param segments [Integer] How smooth to draw the sector
+# @param segments [Integer] How smooth to draw the sector.
 # @param colour [Colour]
 # @return [nil]
 def draw_circle_sector(vector, radius, start_angle, end_angle, segments, colour)
@@ -35,12 +35,12 @@ def draw_circle_sector(vector, radius, start_angle, end_angle, segments, colour)
   nil
 end
 
-# Draw a circle sector outline
+# Draw a circle sector outline.
 # @param vector [Vector2]
 # @param radius [Float]
 # @param start_angle [Float]
 # @param end_angle [Float]
-# @param segments [Integer] How smooth to draw the sector
+# @param segments [Integer] How smooth to draw the sector.
 # @param colour [Colour]
 # @return [nil]
 def draw_circle_sector_lines(vector, radius, start_angle, end_angle, segments, colour)
@@ -49,7 +49,7 @@ def draw_circle_sector_lines(vector, radius, start_angle, end_angle, segments, c
   nil
 end
 
-# Draw a circle filled with a gradient
+# Draw a circle filled with a gradient.
 # @param x [Integer]
 # @param y [Integer]
 # @param radius [Float]
@@ -62,7 +62,7 @@ def draw_circle_gradient(x, y, radius, colour1, colour2)
   nil
 end
 
-# Draw the outline of a circle
+# Draw the outline of a circle.
 # @param x [Integer]
 # @param y [Integer]
 # @param radius [Float]

--- a/mrb_doc/shapes/collision.rb
+++ b/mrb_doc/shapes/collision.rb
@@ -1,4 +1,4 @@
-# Checks if a Vector2 is inside a Rectangle
+# Checks if a {Vector2} is inside a {Rectangle}.
 # @param point [Vector2]
 # @param rectangle [Rectangle]
 # @return [Boolean]

--- a/mrb_doc/shapes/ellipse.rb
+++ b/mrb_doc/shapes/ellipse.rb
@@ -1,8 +1,8 @@
-# Draw an ellipse
+# Draw an ellipse.
 # @param x [Integer]
 # @param y [Integer]
-# @param radius_h [Float] The horizontal radius
-# @param radius_v [Float] The vertical radius
+# @param radius_h [Float] The horizontal radius.
+# @param radius_v [Float] The vertical radius.
 # @param colour [Colour]
 # @return [nil]
 def draw_ellipse(x, y, radius_h, radius_v, colour)
@@ -11,11 +11,11 @@ def draw_ellipse(x, y, radius_h, radius_v, colour)
   nil
 end
 
-# Draw the outline of an ellipse
+# Draw the outline of an ellipse.
 # @param x [Integer]
 # @param y [Integer]
-# @param radius_h [Float] The horizontal radius
-# @param radius_v [Float] The vertical radius
+# @param radius_h [Float] The horizontal radius.
+# @param radius_v [Float] The vertical radius.
 # @param colour [Colour]
 # @return [nil]
 def draw_ellipse_lines(x, y, radius_h, radius_v, colour)

--- a/mrb_doc/shapes/line.rb
+++ b/mrb_doc/shapes/line.rb
@@ -1,4 +1,4 @@
-# Draw a line between the start and end points
+# Draw a line between the start and end points.
 # @param start_x [Integer]
 # @param start_y [Integer]
 # @param end_x [Integer]
@@ -11,7 +11,7 @@ def draw_line(start_x, start_y, end_x, end_y, colour)
   nil
 end
 
-# Draw a line between the start and end points using Vector2s
+# Draw a line between the start and end points using {Vector2}s.
 # @param start [Vector2]
 # @param stop [Vector2]
 # @param colour [Colour]
@@ -22,7 +22,7 @@ def draw_line_v(start, stop, colour)
   nil
 end
 
-# Draw a line between the start and end points using Vector2s and specified thickness
+# Draw a line between the start and end points using {Vector2}s and specified thickness.
 # @param start [Vector2]
 # @param stop [Vector2]
 # @param thickness [Float]
@@ -34,7 +34,7 @@ def draw_line_ex(start, stop, thickness, colour)
   nil
 end
 
-# Draw a bezier curve between the start and end points using Vector2s and specified thickness
+# Draw a bezier curve between the start and end points using {Vector2}s and specified thickness.
 # @param start [Vector2]
 # @param stop [Vector2]
 # @param thickness [Float]
@@ -46,7 +46,7 @@ def draw_line_bezier(start, stop, thickness, colour)
   nil
 end
 
-# Draw a bezier curve between the start and end points passing through the control using Vector2s and specified thickness
+# Draw a bezier curve between the start and end points passing through the control using {Vector2}s and specified thickness
 # @param start [Vector2]
 # @param stop [Vector2]
 # @param control [Vector2]

--- a/mrb_doc/shapes/line.rb
+++ b/mrb_doc/shapes/line.rb
@@ -59,10 +59,10 @@ def draw_line_bezier_quad(start, stop, control, thickness, colour)
   nil
 end
 
-# I honestly don't know how this method is supposed to work, I thought I had
-# bugs in my code but reproducing it in plain C++ causes it to do the same
-# things. As far as I can tell it just draws a line from 0, 0 to the first
-# vector and nothing else.
+# @note I honestly don't know how this method is supposed to work, I thought I had
+#   bugs in my code but reproducing it in plain C++ causes it to do the same
+#   things. As far as I can tell it just draws a line from 0, 0 to the first
+#   vector and nothing else.
 # @param vectors [Array<Vector2>]
 # @param colour [Colour]
 # @return [nil]

--- a/mrb_doc/shapes/pixel.rb
+++ b/mrb_doc/shapes/pixel.rb
@@ -1,4 +1,4 @@
-# Draw a pixel
+# Draw a pixel.
 # @param x [Integer]
 # @param y [Integer]
 # @param colour [Colour]
@@ -9,7 +9,7 @@ def draw_pixel(x, y, colour)
   nil
 end
 
-# Draw a pixel using a Vector2
+# Draw a pixel using a {Vector2}.
 # @param position [Vector2]
 # @param colour [Colour]
 # @return [nil]

--- a/mrb_doc/shapes/rectangle.rb
+++ b/mrb_doc/shapes/rectangle.rb
@@ -1,4 +1,4 @@
-# Draw a rectangle
+# Draw a rectangle.
 # @param x [Integer]
 # @param y [Integer]
 # @param width [Integer]
@@ -11,7 +11,7 @@ def draw_rectangle(x, y, width, height, colour)
   nil
 end
 
-# Draw a rectangle
+# Draw a rectangle.
 # @param rectangle [Rectangle]
 # @param colour [Colour]
 # @return [nil]
@@ -21,7 +21,7 @@ def draw_rectangle_rec(rectangle, colour)
   nil
 end
 
-# Draw a rectangle with rotation
+# Draw a rectangle with rotation.
 # @param rectangle [Rectangle]
 # @param origin [Vector2]
 # @param rotation [Float]
@@ -32,8 +32,8 @@ def draw_rectangle_pro(rectangle, origin, rotation, colour)
   # src/mruby_integration/shapes/rectangle.cpp
   nil
 end
-
-# Draw a rectangle with a gradient vertically
+  
+# Draw a rectangle with a gradient vertically.
 # @param x [Integer]
 # @param y [Integer]
 # @param width [Integer]
@@ -47,7 +47,7 @@ def draw_rectangle_gradient_v(x, y, width, height, colour1, colour2)
   nil
 end
 
-# Draw a rectangle with a gradient horizontally
+# Draw a rectangle with a gradient horizontally.
 # @param x [Integer]
 # @param y [Integer]
 # @param width [Integer]
@@ -61,7 +61,7 @@ def draw_rectangle_gradient_h(x, y, width, height, colour1, colour2)
   nil
 end
 
-# Draw a rectangle with a gradient from each vertex
+# Draw a rectangle with a gradient from each vertex.
 # @param rectangle [Rectangle]
 # @param colour1 [Colour]
 # @param colour2 [Colour]
@@ -74,7 +74,7 @@ def draw_rectangle_gradient_ex(rectangle, colour1, colour2, colour3, colour4)
   nil
 end
 
-# Draw a rectangle outline
+# Draw a rectangle outline.
 # @param x [Integer]
 # @param y [Integer]
 # @param width [Integer]
@@ -87,7 +87,7 @@ def draw_rectangle_lines(x, y, width, height, colour)
   nil
 end
 
-# Draw a rectangle outline with the specific thickness
+# Draw a rectangle outline with the specific thickness.
 # @param rectangle [Rectangle]
 # @param thickness [Integer]
 # @param colour [Colour]
@@ -98,10 +98,10 @@ def draw_rectangle_lines_ex(rectangle, thickness, colour)
   nil
 end
 
-# Draw a rectangle with rounded corners
+# Draw a rectangle with rounded corners.
 # @param rectangle [Rectangle]
-# @param radius [Float] A value between 0.0 and 1.0
-# @param segments [Integer] How smooth to draw the corners
+# @param radius [Float] A value between 0.0 and 1.0.
+# @param segments [Integer] How smooth to draw the corners.
 # @param colour [Colour]
 # @return [nil]
 def draw_rectangle_rounded(rectangle, radius, segments, colour)
@@ -109,11 +109,11 @@ def draw_rectangle_rounded(rectangle, radius, segments, colour)
   # src/mruby_integration/shapes/rectangle.cpp
   nil
 end
-
-# Draw the outline of a rectangle with rounded corners
+  
+# Draw the outline of a rectangle with rounded corners.
 # @param rectangle [Rectangle]
-# @param radius [Float] A value between 0.0 and 1.0
-# @param segments [Integer] How smooth to draw the corners
+# @param radius [Float] A value between 0.0 and 1.0.
+# @param segments [Integer] How smooth to draw the corners.
 # @param thickness [Integer]
 # @param colour [Colour]
 # @return [nil]

--- a/mrb_doc/shapes/ring.rb
+++ b/mrb_doc/shapes/ring.rb
@@ -1,10 +1,10 @@
-# Draw a ring
+# Draw a ring.
 # @param vector [Vector]
 # @param inner_radius [Float]
 # @param outer_radius [Float]
 # @param start_angle [Float]
 # @param end_angle [Float]
-# @param segments [Integer] How smooth to draw the sector
+# @param segments [Integer] How smooth to draw the sector.
 # @param colour [Colour]
 # @return [nil]
 def draw_ring(vector, inner_radius, outer_radius, start_angle, end_angle, segments, colour)
@@ -13,13 +13,13 @@ def draw_ring(vector, inner_radius, outer_radius, start_angle, end_angle, segmen
   nil
 end
 
-# Draw the outline of a ring
+# Draw the outline of a ring.
 # @param vector [Vector]
 # @param inner_radius [Float]
 # @param outer_radius [Float]
 # @param start_angle [Float]
 # @param end_angle [Float]
-# @param segments [Integer] How smooth to draw the sector
+# @param segments [Integer] How smooth to draw the sector.
 # @param colour [Colour]
 # @return [nil]
 def draw_ring_lines(vector, inner_radius, outer_radius, start_angle, end_angle, segments, colour)

--- a/mrb_doc/shapes/triangle.rb
+++ b/mrb_doc/shapes/triangle.rb
@@ -1,4 +1,4 @@
-# Draw a triangle
+# Draw a triangle.
 # @param left [Vector2]
 # @param right [Vector2]
 # @param top [Vector2]
@@ -10,7 +10,7 @@ def draw_triangle(left, right, top, colour)
   nil
 end
 
-# Draw the outline of a triangle
+# Draw the outline of a triangle.
 # @param left [Vector2]
 # @param right [Vector2]
 # @param top [Vector2]

--- a/mrb_doc/textures.rb
+++ b/mrb_doc/textures.rb
@@ -63,7 +63,7 @@ end
 
 # Sets the filtering for the {Texture2D}.
 # @param texture [Texture2D]
-# @param filter [Integer] What sort of filtering to apply, valid options are: {TEXTURE_FILTER_POINT}, {TEXTURE_FILTER_BILINEAR}, {TEXTURE_FILTER_TRILINEAR}, {TEXTURE_FILTER_ANISOTROPIC_4X}, {TEXTURE_FILTER_ANISOTROPIC_8X}, or {TEXTURE_FILTER_ANISOTROPIC_16X}.
+# @param filter [Integer] What sort of filtering to apply, valid options are: {TEXTURE_FILTER_POINT}, {TEXTURE_FILTER_BILINEAR}, {TEXTURE_FILTER_TRILINEAR}, {TEXTURE_FILTER_ANISOTROPIC_4X}, {TEXTURE_FILTER_ANISOTROPIC_8X} or {TEXTURE_FILTER_ANISOTROPIC_16X}.
 # @return [nil]
 def set_texture_filter(texture, filter)
   # mrb_set_texture_filter

--- a/mrb_doc/textures.rb
+++ b/mrb_doc/textures.rb
@@ -1,4 +1,4 @@
-# Loads a texture from a file
+# Loads a texture from a file.
 # @param path [String]
 # @return [Texture2D]
 def load_texture(path)
@@ -7,7 +7,7 @@ def load_texture(path)
   Texture2D.new
 end
 
-# Unloads a texture
+# Unloads a texture.
 # @param texture [Texture2D]
 # @return [nil]
 def unload_texture(texture)
@@ -16,7 +16,7 @@ def unload_texture(texture)
   nil
 end
 
-# Draws a texture, the colour will apply a tint and alpha levels
+# Draws a texture, the colour will apply a tint and alpha levels.
 # @param texture [Texture2D]
 # @param x [Integer]
 # @param y [Integer]
@@ -29,7 +29,7 @@ def draw_texture(texture, x, y, colour)
 end
 
 # Draws a section of texture with the specified rotation to the scaled to the
-# destination rectangle, the colour will apply a tint and alpha levels
+# destination rectangle, the colour will apply a tint and alpha levels.
 # @param texture [Texture2D]
 # @param source [Rectangle]
 # @param destination [Rectangle]
@@ -43,8 +43,8 @@ def draw_texture_pro(texture, source, destination, origin, rotation, colour)
   nil
 end
 
-# Returns a new colour which is a faded version of the original
-# @param colour [Colour
+# Returns a new colour which is a faded version of the original.
+# @param colour [Colour]
 # @return [Colour]
 def fade(colour)
   # mrb_fade
@@ -52,7 +52,7 @@ def fade(colour)
   Colour.new
 end
 
-# Generates mipmaps for the {Texture2D}
+# Generates mipmaps for the {Texture2D}.
 # @param texture [Texture2D]
 # @return [nil]
 def generate_texture_mipmaps(texture)
@@ -61,9 +61,9 @@ def generate_texture_mipmaps(texture)
   nil
 end
 
-# Sets the filtering for the {Texture2D}
+# Sets the filtering for the {Texture2D}.
 # @param texture [Texture2D]
-# @param filter [Integer] What sort of filtering to apply, valid options are: {TEXTURE_FILTER_POINT}, {TEXTURE_FILTER_BILINEAR}, {TEXTURE_FILTER_TRILINEAR}, {TEXTURE_FILTER_ANISOTROPIC_4X}, {TEXTURE_FILTER_ANISOTROPIC_8X}, or {TEXTURE_FILTER_ANISOTROPIC_16X}
+# @param filter [Integer] What sort of filtering to apply, valid options are: {TEXTURE_FILTER_POINT}, {TEXTURE_FILTER_BILINEAR}, {TEXTURE_FILTER_TRILINEAR}, {TEXTURE_FILTER_ANISOTROPIC_4X}, {TEXTURE_FILTER_ANISOTROPIC_8X}, or {TEXTURE_FILTER_ANISOTROPIC_16X}.
 # @return [nil]
 def set_texture_filter(texture, filter)
   # mrb_set_texture_filter

--- a/mrb_doc/textures.rb
+++ b/mrb_doc/textures.rb
@@ -28,7 +28,7 @@ def draw_texture(texture, x, y, colour)
   nil
 end
 
-# Draws a section of texture with the specified rotation to the scaled to the
+# Draws a section of texture with the specified rotation, scaled to the
 # destination rectangle, the colour will apply a tint and alpha levels.
 # @param texture [Texture2D]
 # @param source [Rectangle]

--- a/mrb_doc/web.rb
+++ b/mrb_doc/web.rb
@@ -1,7 +1,7 @@
-# Sets the main loop for web exports
+# Sets the main loop for web exports.
 # @param method [String]
 # @return [nil]
-# @raise [PlatformSpecificMethodCalledOnWrongPlatformError] If run on the wrong platform
+# @raise [PlatformSpecificMethodCalledOnWrongPlatformError] If run on the wrong platform.
 def set_main_loop(method)
   # mrb_set_main_loop
   # src/web.cpp


### PR DESCRIPTION
Hey there, so this PR is the continuation from #27 but based on the refactor. This time I checked all the files under `mrb_doc/`. So `src/ruby/` is left.

### Notable Changes

- Usage of the `@example` tag for code snippets instead of monospaced formatting. 
  Before:
  ![imagen](https://github.com/HellRok/Taylor/assets/83732118/48d2cbca-f88b-4ed6-8a2d-b940b1447b0b)
  After:
  ![imagen](https://github.com/HellRok/Taylor/assets/83732118/4076c096-73c4-447f-a77e-93258251ab57)
- Usage of braces to link classes in the docs instead of monospaced formatting.

---

Also, other change I've gone ahead and did is to format some code snippets that have code like this:
```ruby
puts some_value 
# => 123
```
To this:
```ruby
puts some_value # => 123
```

IMO the latter form with the inline comment is easier to read, since you don't have to go down a line to find the commentthat indicates the return value of the method. What do you think?