### PR TITLE
Use GitHub Markdown Alert Extension on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ If you'd like to see some examples, check them out on the [online playground!](h
 
 ## Compile Yourself!
 
-**Note**: Currently there are no instructions for Windows and OSX.
+> [!NOTE]
+> Currently there are no instructions for Windows and OSX.
 
 ### Linux
 


### PR DESCRIPTION
GitHub's Markdown flavor has an [alert extension](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts). It's basically a fancy render for notes, tips, warnings and other advices on Markdown.

It looks like this

![alerts example](https://github.com/user-attachments/assets/e454f8fe-aa58-4cf1-ac43-92badd1961dc)
