### PR TITLE
Add Basic Blending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -148,6 +148,7 @@
 - Removed get_mouse_wheel_move
 - Add Cursor.icon, Cursor.icon=, and Cursor icon constants
 - Removed set_mouse_cursor
+- Add blend_mode
 
 ## v0.3.14.1
 

--- a/src/mruby_integration/core/drawing.cpp
+++ b/src/mruby_integration/core/drawing.cpp
@@ -80,6 +80,23 @@ mrb_end_scissor_mode(mrb_state*, mrb_value) -> mrb_value
   return mrb_nil_value();
 }
 
+auto
+mrb_begin_blend_mode(mrb_state* mrb, mrb_value) -> mrb_value
+{
+  mrb_int blend_mode;
+  mrb_get_args(mrb, "i", &blend_mode);
+
+  BeginBlendMode(blend_mode);
+  return mrb_nil_value();
+}
+
+auto
+mrb_end_blend_mode(mrb_state*, mrb_value) -> mrb_value
+{
+  EndBlendMode();
+  return mrb_nil_value();
+}
+
 void
 append_core_drawing(mrb_state* mrb)
 {
@@ -124,6 +141,16 @@ append_core_drawing(mrb_state* mrb)
                     mrb->kernel_module,
                     "end_scissor_mode",
                     mrb_end_scissor_mode,
+                    MRB_ARGS_NONE());
+  mrb_define_method(mrb,
+                    mrb->kernel_module,
+                    "begin_blend_mode",
+                    mrb_begin_blend_mode,
+                    MRB_ARGS_REQ(1));
+  mrb_define_method(mrb,
+                    mrb->kernel_module,
+                    "end_blend_mode",
+                    mrb_end_blend_mode,
                     MRB_ARGS_NONE());
 
   load_ruby_core_drawing(mrb);

--- a/src/ruby/core/drawing.rb
+++ b/src/ruby/core/drawing.rb
@@ -26,3 +26,39 @@ def scissor_mode(section, &block)
 ensure
   end_scissor_mode
 end
+
+# Allows you to call rendering functions within the block using blending.
+# @yield The block that calls your rendering logic.
+# @param mode [Integer] Must be one of {BLEND_ALPHA}, {BLEND_ADDITIVE},
+#   {BLEND_MULTIPLIED}, {BLEND_ADD_COLORS}, {BLEND_SUBTRACT_COLORS},
+#   {BLEND_ALPHA_PREMULTIPLY}, {BLEND_CUSTOM}, {BLEND_CUSTOM_SEPARATE}
+# @return [nil]
+def blend_mode(mode = BLEND_ALPHA, &block)
+  begin_blend_mode(mode)
+  block.call
+ensure
+  end_blend_mode
+end
+
+# @!group Blend modes
+
+# Blend textures considering alpha.
+BLEND_ALPHA = 0
+# Blend textures adding colors.
+BLEND_ADDITIVE = 1
+# Blend textures multiplying colors.
+BLEND_MULTIPLIED = 2
+# Blend textures adding colors (alternative).
+BLEND_ADD_COLORS = 3
+# Blend textures subtracting colors (alternative).
+BLEND_SUBTRACT_COLORS = 4
+# Blend premultiplied textures considering alpha.
+BLEND_ALPHA_PREMULTIPLY = 5
+# Blend textures using custom src/dst factors.
+# @note Currently you can't set custom blend factors.
+BLEND_CUSTOM = 6
+# Blend textures using custom rgb/alpha separate src/dst factors.
+# @note Currently you can't set custom blend factors.
+BLEND_CUSTOM_SEPARATE = 7
+
+# @!endgroup

--- a/test/core/drawing_test.rb
+++ b/test/core/drawing_test.rb
@@ -53,6 +53,49 @@ class Test
         end
         assert_equal fixture_core_drawing_scissor_mode, get_screen_data.data
       end
+
+      def test_blend_mode
+        skip_unless_display_present
+
+        set_window_title(__method__.to_s)
+
+        red = Image.generate(width: 2, height: 2, colour: Colour::RED).to_texture
+        green = Image.generate(width: 2, height: 2, colour: Colour::GREEN).to_texture
+        green_transparent = Image.generate(width: 2, height: 2, colour: Colour[0, 228, 48, 127]).to_texture
+        drawing do
+          red.draw(destination: Rectangle.new(0, 0, 2, 2))
+          blend_mode(BLEND_ADDITIVE) do
+            green.draw(destination: Rectangle.new(0, 0, 2, 2))
+          end
+
+          red.draw(destination: Rectangle.new(2, 0, 2, 2))
+          blend_mode(BLEND_MULTIPLIED) do
+            green.draw(destination: Rectangle.new(2, 0, 2, 2))
+          end
+
+          red.draw(destination: Rectangle.new(4, 0, 2, 2))
+          blend_mode(BLEND_ADD_COLORS) do
+            green.draw(destination: Rectangle.new(4, 0, 2, 2))
+          end
+
+          red.draw(destination: Rectangle.new(6, 0, 2, 2))
+          blend_mode(BLEND_SUBTRACT_COLORS) do
+            green.draw(destination: Rectangle.new(6, 0, 2, 2))
+          end
+
+          red.draw(destination: Rectangle.new(8, 0, 2, 2))
+          blend_mode(BLEND_ALPHA) do
+            green_transparent.draw(destination: Rectangle.new(8, 0, 2, 2))
+          end
+
+          red.draw(destination: Rectangle.new(0, 2, 2, 2))
+          blend_mode(BLEND_ALPHA_PREMULTIPLY) do
+            green_transparent.draw(destination: Rectangle.new(0, 2, 2, 2))
+          end
+        end
+
+        assert_equal fixture_core_drawing_blend_mode, get_screen_data.data
+      end
     end
   end
 end

--- a/test/fixtures/core/drawing.rb
+++ b/test/fixtures/core/drawing.rb
@@ -26,3 +26,28 @@ def fixture_core_drawing_scissor_mode
     w, w, w, w, w, w, w, w, w, w
   ]
 end
+
+def fixture_core_drawing_blend_mode
+  wh = Colour::RAYWHITE
+
+  # Used red as base and green as overlay
+  # NOTE: In alpha and premultiplied alpha green was 50% transparent
+  ad = Colour.new(red: 230, green: 255, blue: 103, alpha: 255) # Additive
+  mu = Colour.new(red: 0, green: 37, blue: 10, alpha: 255) # Multiplied
+  ac = Colour.new(red: 230, green: 255, blue: 103, alpha: 255) # Add colors
+  su = Colour.new(red: 0, green: 187, blue: 0, alpha: 255) # Subtract colors
+  al = Colour.new(red: 115, green: 134, blue: 52, alpha: 255) # Alpha
+  ap = Colour.new(red: 115, green: 249, blue: 76, alpha: 255) # Alpha premultiply
+  [
+    ad, ad, mu, mu, ac, ac, su, su, al, al,
+    ad, ad, mu, mu, ac, ac, su, su, al, al,
+    ap, ap, wh, wh, wh, wh, wh, wh, wh, wh,
+    ap, ap, wh, wh, wh, wh, wh, wh, wh, wh,
+    wh, wh, wh, wh, wh, wh, wh, wh, wh, wh,
+    wh, wh, wh, wh, wh, wh, wh, wh, wh, wh,
+    wh, wh, wh, wh, wh, wh, wh, wh, wh, wh,
+    wh, wh, wh, wh, wh, wh, wh, wh, wh, wh,
+    wh, wh, wh, wh, wh, wh, wh, wh, wh, wh,
+    wh, wh, wh, wh, wh, wh, wh, wh, wh, wh
+  ]
+end


### PR DESCRIPTION
Adds blend modes for rendering textures. The syntax is similar to the `scissor_mode`:
```ruby
drawing do
  # Draw normal textures here
  blend_mode(BLEND_ADDITIVE) do
    # Draw blended textures here
  end
end
```

While I've defined `BLEND_CUSTOM` and `BLEND_CUSTOM_SEPARATE`, they're no-op since we didn't wrap the necessary functions from Raylib.

Closes #32.
