### PR TITLE
Documentation test now requires all ruby files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add Colour#tint and Colour#tint!
 - Add Colour#brightness and Colour#brightness!
 - Fix documentation for Window
+- Documentation check now requires all files
 
 ## v0.4.0
 

--- a/bin/test-documentation
+++ b/bin/test-documentation
@@ -1,5 +1,9 @@
 #!/usr/bin/env ruby
 
+# Load all the files to make sure they're valid Ruby
+Dir.glob("./mrb_doc/**/*.rb") { require it }
+Dir.glob("./src/ruby/**/*.rb") { require it }
+
 IGNORED_FILES = [
   "./src/mruby_integration/models/local_storage.cpp",
   "./src/taylor/raylib.cpp"

--- a/mrb_doc/models/camera2d.rb
+++ b/mrb_doc/models/camera2d.rb
@@ -22,7 +22,6 @@ class Camera2D
   def initialize(target: Vector2[0, 0], offset: Vector2[0, 0], rotation: 0, zoom: 1)
     # mrb_Camera2D_initialize
     # src/mruby_integration/models/camera2d.cpp
-    Camera2D.new
   end
 
   # Draws the world through the lens of the {Camera2D}.

--- a/mrb_doc/models/circle.rb
+++ b/mrb_doc/models/circle.rb
@@ -27,7 +27,6 @@ class Circle
   def initialize(x:, y:, radius:, colour:, outline: nil, thickness: 1, gradient: nil)
     # mrb_Circle_initialize
     # src/mruby_integration/models/circle.cpp
-    Circle.new
   end
 
   # Draws the {Circle}.

--- a/mrb_doc/models/colour.rb
+++ b/mrb_doc/models/colour.rb
@@ -12,10 +12,9 @@ class Colour
   # @param green [Integer] A value between 0 and 255.
   # @param alpha [Integer] A value between 0 and 255.
   # @return [Colour]
-  def initialize(red, green, blue, alpha)
+  def initialize(red: 0, green: 0, blue: 0, alpha: 255)
     # mrb_Colour_initialize
     # src/mruby_integration/models/colour.cpp
-    Colour.new
   end
 
   # Returns a new {Colour} which is a faded version of the original.

--- a/mrb_doc/models/font.rb
+++ b/mrb_doc/models/font.rb
@@ -27,7 +27,6 @@ class Font
   def initialize(path, size: 32, glyph_count: 95)
     # mrb_Font_initialize
     # src/mruby_integration/models/font.cpp
-    Font.new
   end
 
   # Draw the text to the screen using the loaded {Font}.

--- a/mrb_doc/models/gamepad.rb
+++ b/mrb_doc/models/gamepad.rb
@@ -32,7 +32,6 @@ class Gamepad
   def initialize(index:)
     # mrb_Gamepad_initialize
     # src/mruby_integration/models/gamepad.cpp
-    Gamepad[0]
   end
 
   # Used for checking if the {Gamepad} at this index is still available for use.

--- a/mrb_doc/models/image.rb
+++ b/mrb_doc/models/image.rb
@@ -28,7 +28,6 @@ class Image
   def initialize(path)
     # mrb_Image_initialize
     # src/mruby_integration/models/image.cpp
-    Image.new
   end
 
   # Unloads the {Image} from memory.

--- a/mrb_doc/models/line.rb
+++ b/mrb_doc/models/line.rb
@@ -21,7 +21,6 @@ class Line
   def initialize(start:, end:, colour:, thickness: 1.0)
     # mrb_Line_initialize
     # src/mruby_integration/models/line.cpp
-    Line.new
   end
 
   # Draws the {Line}.

--- a/mrb_doc/models/monitor.rb
+++ b/mrb_doc/models/monitor.rb
@@ -49,7 +49,6 @@ class Monitor
   def initialize(id:)
     # mrb_Monitor_initialize
     # src/mruby_integration/models/monitor.cpp
-    Monitor[0]
   end
 
   # Returns the position of the {Monitor} as a {Vector2}.

--- a/mrb_doc/models/music.rb
+++ b/mrb_doc/models/music.rb
@@ -17,7 +17,6 @@ class Music
   def initialize(path, looping: true, volume: 1.0, pitch: 1.0)
     # mrb_Music_initialize
     # src/mruby_integration/models/music.cpp
-    Music.new
   end
 
   # Unloads the {Music} from memory.

--- a/mrb_doc/models/rectangle.rb
+++ b/mrb_doc/models/rectangle.rb
@@ -27,7 +27,6 @@ class Rectangle
   def initialize(x:, y:, width:, height:, colour: Colour::BLACK, outline: nil, thickness: 1, roundness: 0, segments: 4)
     # mrb_Rectangle_initialize
     # src/mruby_integration/models/rectangle.cpp
-    Rectangle.new
   end
 
   # Draws the {Rectangle}.

--- a/mrb_doc/models/render_texture.rb
+++ b/mrb_doc/models/render_texture.rb
@@ -13,7 +13,6 @@ class RenderTexture
   def initialize(width:, height:)
     # mrb_RenderTexture_initialize
     # src/mruby_integration/models/render_texture.cpp
-    RenderTexture.new
   end
 
   # Unloads the {RenderTexture} from memory.

--- a/mrb_doc/models/shader.rb
+++ b/mrb_doc/models/shader.rb
@@ -47,7 +47,6 @@ class Shader
   def initialize(fragment:, vertex:)
     # mrb_Shader_initialize
     # src/mruby_integration/models/shader.cpp
-    Shader.new
   end
 
   # Unloads the Shader from memory.

--- a/mrb_doc/models/sound.rb
+++ b/mrb_doc/models/sound.rb
@@ -17,7 +17,6 @@ class Sound
   def initialize(path, volume: 1.0, pitch: 1.0)
     # mrb_Sound_initialize
     # src/mruby_integration/models/sound.cpp
-    Sound.new
   end
 
   # Unloads the {Sound} from memory.

--- a/mrb_doc/models/texture2d.rb
+++ b/mrb_doc/models/texture2d.rb
@@ -11,7 +11,6 @@ class Texture2D
   def initialize(path)
     # mrb_Texture2D_initialize
     # src/mruby_integration/models/texture2d.cpp
-    Texture2D.new
   end
 
   # Unloads the {Texture2D} from memory.

--- a/mrb_doc/models/vector2.rb
+++ b/mrb_doc/models/vector2.rb
@@ -13,7 +13,6 @@ class Vector2
   def initialize(x:, y:)
     # mrb_Vector2_initialize
     # src/mruby_integration/models/vector2.cpp
-    Vector2.new
   end
 
   # Sets the corresponding pixel to the passed in {Colour}.


### PR DESCRIPTION
This would have caught the issue that stopped half the Window module from being documented.

I've also removed the circular references in all `initialize` methods as they could (and did!) cause stack overflow issues.