### PR TITLE
Improve the speed of web tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix documentation for Window
 - Documentation check now requires all files
 - Added a pull request template
+- Fix browser test speed
 
 ## v0.4.0
 

--- a/test/test.rb
+++ b/test/test.rb
@@ -61,6 +61,8 @@ require "taylor/platform_test"
 require "taylor_test"
 
 if Taylor::Platform.browser?
+  neospec.logger = Neospec::Logger::Symbols.new
+  neospec.suites << @browser
   success = neospec.run
   puts "ANALYTICS: #{File.read("test-analytics.json")}"
   puts "EXIT CODE: #{success ? 0 : 1}"


### PR DESCRIPTION
## What's the change?
Web tests were taking 20+ seconds when linux/windows were running in milliseconds. It turns out the logger I was using was adding a lot of wasted time, so I have switched to the simpler logger.

Also, I wasn't adding the @browser suite, so corrected that.

## Checklist

- [X] Added tests
- [X] Added documentation
- [X] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [X] Added an entry to `changelog.md`
- [X] Run `dx/exec bin/test`
