### PR TITLE
Texture2D#origin now defaults to Vector2[0, 0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Switch to LocalCI
 - Uploading test analytics doesn't explode without a key set
 - `clang-format` update settings
+- Texture2D doesn't set the origin to the centre by default
 
 ## v0.4.0
 

--- a/mrb_doc/migrations/0_4_to_0_5.md
+++ b/mrb_doc/migrations/0_4_to_0_5.md
@@ -1,2 +1,5 @@
 # Migrating from 0.4 to 0.5
 
+## Texture2D#draw
+
+The origin no longer defaults to the centre of the destination.

--- a/mrb_doc/models/texture2d.rb
+++ b/mrb_doc/models/texture2d.rb
@@ -112,15 +112,22 @@ class Texture2D
   #   sheet.draw(source: player, position: Vector2[32, 32])
   #
   #
-  # @param source [Rectangle] If not defined it defaults to the full image
-  # @param position [Vector2] If not defined it defaults to Vector2[0, 0]
-  # @param destination [Rectangle] If not defined it defaults to position x and y with source width and height
-  # @param origin [Vector2] Defaults to the middle of the `destination`
+  # @param source [Rectangle]
+  # @param position [Vector2]
+  # @param destination [Rectangle]
+  # @param origin [Vector2]
   # @param rotation [Integer] In degrees
   # @param colour [Colour]
   # @return [nil]
   # @raise [ArgumentError] if both `position` and `destination` are passed in
-  def draw(source: Rectangle[0, 0, width, height], position: nil, destination: nil, origin: Vector2[destination.width / 2.0, destination.height / 2.0], rotation: 0, colour: Colour::WHITE)
+  def draw(
+    source: Rectangle[0, 0, width, height],
+    position: Vector2[0, 0],
+    destination: Rectangle[position.x, position.y, source.width, source.height],
+    origin: Vector2[0, 0],
+    rotation: 0,
+    colour: Colour::WHITE
+  )
     # mrb_Texture2D_draw
     # src/mruby_integration/models/texture2d.cpp
     nil

--- a/src/mruby_integration/models/texture2d.cpp
+++ b/src/mruby_integration/models/texture2d.cpp
@@ -168,7 +168,7 @@ auto mrb_Texture2D_draw(mrb_state* mrb, mrb_value self) -> mrb_value
 
   Vector2* origin;
   if (mrb_undef_p(kw_values[3])) {
-    auto default_origin = Vector2{ (destination->width / 2.0f), (destination->height / 2.0f) };
+    auto default_origin = Vector2{ 0, 0 };
     origin = &default_origin;
   } else {
     origin = static_cast<struct Vector2*> DATA_PTR(kw_values[3]);

--- a/test/models/texture2d_test.rb
+++ b/test/models/texture2d_test.rb
@@ -191,7 +191,7 @@ end
           "texture: { id: 5 width: 6 height: 7 mipmaps: 8 format: 9 } " \
           "source: { x: 0.000000 y: 0.000000 width: 6.000000 height: 7.000000 } " \
           "dest: { x: 0.000000 y: 0.000000 width: 6.000000 height: 7.000000 } " \
-          "origin: { x: 3.000000 y: 3.500000 } " \
+          "origin: { x: 0.000000 y: 0.000000 } " \
           "rotation: 0.000000 " \
           "tint: { r: 255 g: 255 b: 255 a: 255 } " \
         "}"
@@ -235,7 +235,7 @@ end
           "texture: { id: 5 width: 6 height: 7 mipmaps: 8 format: 9 } " \
           "source: { x: 10.000000 y: 11.000000 width: 12.000000 height: 13.000000 } " \
           "dest: { x: 0.000000 y: 0.000000 width: 12.000000 height: 13.000000 } " \
-          "origin: { x: 6.000000 y: 6.500000 } " \
+          "origin: { x: 0.000000 y: 0.000000 } " \
           "rotation: 0.000000 " \
           "tint: { r: 255 g: 255 b: 255 a: 255 } " \
         "}"
@@ -254,7 +254,7 @@ end
           "texture: { id: 5 width: 6 height: 7 mipmaps: 8 format: 9 } " \
           "source: { x: 0.000000 y: 0.000000 width: 6.000000 height: 7.000000 } " \
           "dest: { x: 10.000000 y: 11.000000 width: 6.000000 height: 7.000000 } " \
-          "origin: { x: 3.000000 y: 3.500000 } " \
+          "origin: { x: 0.000000 y: 0.000000 } " \
           "rotation: 0.000000 " \
           "tint: { r: 255 g: 255 b: 255 a: 255 } " \
         "}"
@@ -273,7 +273,7 @@ end
           "texture: { id: 5 width: 6 height: 7 mipmaps: 8 format: 9 } " \
           "source: { x: 0.000000 y: 0.000000 width: 6.000000 height: 7.000000 } " \
           "dest: { x: 10.000000 y: 11.000000 width: 12.000000 height: 13.000000 } " \
-          "origin: { x: 6.000000 y: 6.500000 } " \
+          "origin: { x: 0.000000 y: 0.000000 } " \
           "rotation: 0.000000 " \
           "tint: { r: 255 g: 255 b: 255 a: 255 } " \
         "}"


### PR DESCRIPTION
Merge #58 first

## What's the Change?

I had made the change in the big v0.4 re-design to have this be the centre of the destination but having used it that way felt awkward and it made it inconsistent with drawing other objects like Rectangle.

## Checklist

- [x] Added tests
- [x] Added documentation
- [x] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [x] Added an entry to `changelog.md`
- [x] Run `dx/exec bundle exec rake ci`
