### PR TITLE
Don't exit 1 when there isn't a key

### DIFF
--- a/.buildkite/scripts/tests/upload_test_analytics.sh
+++ b/.buildkite/scripts/tests/upload_test_analytics.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-FILE=$1
-TEST_ANALYTICS_KEY=$2
-
-if [[ -z "${TEST_ANALYTICS_KEY+x}" ]]; then
+if [[ -z "${2+x}" ]]; then
   echo "I'm guessing you've hit \"Retry\" since I don't have the test analytics key!"
   exit 0
 fi
 
-if [[ -f $1 ]]; then
+FILE=$1
+TEST_ANALYTICS_KEY=$2
+
+if [[ -f $FILE ]]; then
   echo "Analytics file found, upload '$FILE'"
   curl \
     -X POST \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Fix typo in the game template
 - Rectangle#overlaps? now works with Rectangle using AABB
 - Switch to LocalCI
+- Uploading test analytics doesn't explode without a key set
 
 ## v0.4.0
 


### PR DESCRIPTION
## What's the Change?

When we run a rebuild on BuildKite there is no test analytics key. I'm still not sure _why_ this is but we just check for the existence and move on with our lives.

## Checklist

- [x] Added an entry to `changelog.md`
