### PR TITLE
Lock the version of MRuby used in the export image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Taylor
 
+## Unreleased
+
 ## v0.4.1
 
 - Bump Ruby to 3.4.6 and update gems

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Lock the MRuby version used in the export docker image
+
 ## v0.4.1
 
 - Bump Ruby to 3.4.6 and update gems

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -12,7 +12,7 @@ FROM taylor/build-linux AS build_base
 WORKDIR /app/export
 
 RUN \
-  git clone --branch master --depth 1 https://github.com/mruby/mruby.git /app/mruby &&\
+  git clone --branch 3.4.0 --depth 1 https://github.com/mruby/mruby.git /app/mruby &&\
   cd /app/mruby &&\
   rake
 

--- a/include/version.hpp
+++ b/include/version.hpp
@@ -1,2 +1,2 @@
 #pragma once
-#define VERSION "0.4.1"
+#define VERSION "0.4.2-pre"

--- a/rakelib/helpers.rb
+++ b/rakelib/helpers.rb
@@ -40,6 +40,11 @@ def write_cpp_file(hpp_file, cpp_file, ruby_code)
       mrb_load_string(mrb, R"RUBY(
         #{ruby_code}
       )RUBY");
+
+      if (mrb->exc) {
+        mrb_print_error(mrb);
+        exit(1);
+      }
     }
   CPP
 end

--- a/scripts/export/Rakefile
+++ b/scripts/export/Rakefile
@@ -2,7 +2,7 @@ require "json"
 require "fileutils"
 
 def taylor(args)
-  "taylor /app/taylor/cli-tool/cli.rb #{args}"
+  `taylor /app/taylor/cli-tool/cli.rb #{args}`
 end
 
 options = {
@@ -45,10 +45,8 @@ end
 
 task :squash do
   Dir.chdir("/app/game")
-  File.write(
-    "/app/taylor/output.rb",
-    `#{taylor("squash --stdout")}`
-  )
+  taylor "squash"
+  FileUtils.mv("output.rb", "/app/taylor/output.rb")
   Dir.chdir("/app/export")
 end
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,7 +38,11 @@ auto main(int argc, char** argv) -> int
 
 #ifdef EXPORT
   mrb_load_string(mrb, "Dir.chdir(File.dirname(ARGV.shift))");
-  mrb_load_irep(mrb, game);
+  mrb_value status = mrb_load_irep(mrb, game);
+
+  if (mrb_undef_p(status)) {
+    exit(1);
+  }
 
 #else
   if (argc < 1) {


### PR DESCRIPTION
## What's the Change?

Lock the version of MRuby used in the export image.

The reason for this is I got bit by `mrbc` generating an incompatible `game.h` so that `mrb_load_irep` was failing to load the code. I should have always kept these two in lock but this line was last changed 4~ years ago so I just didn't know better at the time.

## Checklist

- [ ] Added tests
- [ ] Added documentation
- [ ] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [x] Added an entry to `changelog.md`
- [x] Run `dx/exec bundle exec rake ci`
