### PR TITLE
Reworked exporting to use Taylor::Config for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Properly use Taylor::Config through the entire export process
+
 ## v0.4.2
 
 - Lock the MRuby version used in the export docker image

--- a/cli-tool/app/commands/new.rb
+++ b/cli-tool/app/commands/new.rb
@@ -107,6 +107,7 @@ module Taylor
         config_options = options.dup
         config_options.delete(:help)
         config_options.delete(:folder)
+        config_options.transform_keys! { |key| key.to_s.tr("-", "_") }
 
         config = File.open(path_for("taylor-config.json"), "w")
         config.write(JSON.generate(config_options, {pretty_print: true, indent_width: 2}))

--- a/cli-tool/test/commands/new_test.rb
+++ b/cli-tool/test/commands/new_test.rb
@@ -39,12 +39,12 @@ end
     expect(data["version"]).to_equal("v0.0.1")
     expect(data["entrypoint"]).to_equal("game.rb")
     expect(File.exist?("./taylor_game/game.rb")).to_be_true
-    expect(data["export-directory"]).to_equal("./exports")
-    expect(data["export-targets"]).to_equal(["linux", "windows", "osx/apple", "osx/intel", "web"])
-    expect(data["load-paths"]).to_equal(["./", "./vendor"])
+    expect(data["export_directory"]).to_equal("./exports")
+    expect(data["export_targets"]).to_equal(["linux", "windows", "osx/apple", "osx/intel", "web"])
+    expect(data["load_paths"]).to_equal(["./", "./vendor"])
     expect(Dir.exist?("./taylor_game/vendor")).to_be_true
     expect(File.exist?("./taylor_game/vendor/.keep")).to_be_true
-    expect(data["copy-paths"]).to_equal(["./assets"])
+    expect(data["copy_paths"]).to_equal(["./assets"])
     expect(Dir.exist?("./taylor_game/assets")).to_be_true
     expect(File.exist?("./taylor_game/assets/.keep")).to_be_true
   ensure
@@ -72,12 +72,12 @@ end
     expect(data["version"]).to_equal("final_v2_for_real")
     expect(data["entrypoint"]).to_equal("app.rb")
     expect(File.exist?("./test_game/app.rb")).to_be_true
-    expect(data["export-directory"]).to_equal("./releases")
-    expect(data["export-targets"]).to_equal(["web", "windows"])
-    expect(data["load-paths"]).to_equal(["./", "./third_party"])
+    expect(data["export_directory"]).to_equal("./releases")
+    expect(data["export_targets"]).to_equal(["web", "windows"])
+    expect(data["load_paths"]).to_equal(["./", "./third_party"])
     expect(Dir.exist?("./test_game/third_party")).to_be_true
     expect(File.exist?("./test_game/third_party/.keep")).to_be_true
-    expect(data["copy-paths"]).to_equal(["./resources", "./music"])
+    expect(data["copy_paths"]).to_equal(["./resources", "./music"])
     expect(Dir.exist?("./test_game/resources")).to_be_true
     expect(File.exist?("./test_game/resources/.keep")).to_be_true
     expect(Dir.exist?("./test_game/music")).to_be_true

--- a/mrb_doc/migrations/0_4_to_0_5.md
+++ b/mrb_doc/migrations/0_4_to_0_5.md
@@ -10,6 +10,20 @@ The `input` key has been renamed to `entrypoint`. `input` will continue to be
 respected but you should update. New projects are generated with `entrypoint`
 instead.
 
+I have deprecated the following keys:
+
+- `export-directory`
+- `export-targets`
+- `load-paths`
+- `copy-paths`
+
+In favour of:
+
+- `export_directory`
+- `export_targets`
+- `load_paths`
+- `copy_paths`
+
 ## Texture2D#draw
 
 The origin no longer defaults to the centre of the destination.

--- a/rakelib/android.rake
+++ b/rakelib/android.rake
@@ -39,7 +39,7 @@ class AndroidBuilder < Builder
   end
 
   def apk_name(final: false)
-    "#{@options["name"]}#{"-unzipped" unless final}.apk"
+    "#{@options.name}#{"-unzipped" unless final}.apk"
   end
 end
 

--- a/rakelib/builder.rb
+++ b/rakelib/builder.rb
@@ -1,4 +1,5 @@
 require_relative "builder/commands"
+require_relative "../src/ruby/taylor/config"
 
 class Builder
   def self.base
@@ -92,17 +93,17 @@ class Builder
   end
 
   def setup_options
-    @options ||= File.exist?("/app/game/taylor-config.json") ?
-      JSON.parse(File.read("/app/game/taylor-config.json")) : {
-        "name" => "taylor"
-      }
+    return @options if @options
+
+    Dir.chdir("/app/game") { @options = Taylor::Config.new } if ENV["EXPORT"]
+    @options ||= Taylor::Config.new
   end
 
   def name
-    @options["name"]
+    @options.name
   end
 
   def mock_raylib?
-    @options.dig("debugging", "raylib", "mock_implementation") || ENV.key?("MOCK_RAYLIB")
+    @options.debugging.raylib.mock_implementation? || ENV.key?("MOCK_RAYLIB")
   end
 end

--- a/rakelib/web.rake
+++ b/rakelib/web.rake
@@ -13,8 +13,8 @@ class WebBuilder < Builder
   end
 
   def shell_path
-    if @options.dig("web", "shell_path")
-      " --shell-file #{File.join("/", "app", "game", @options["web"]["shell_path"])}"
+    if @options.web.shell_path
+      " --shell-file #{File.join("/", "app", "game", @options.web.shell_path)}"
     else
       " --shell-file ./scripts/export/emscripten_shell.html"
     end
@@ -23,17 +23,16 @@ class WebBuilder < Builder
   def generate_static_links
     @static_links << "-s USE_GLFW=3"
 
-    total_memory = @options.dig("web", "total_memory")
-    @static_links << if total_memory.nil?
+    @static_links << if @options.web.total_memory.nil?
       " -s TOTAL_MEMORY=64MB"
-    elsif total_memory == -1
+    elsif @options.web.total_memory == -1
       " -s ALLOW_MEMORY_GROWTH"
     else
-      " -s TOTAL_MEMORY=#{total_memory}MB"
+      " -s TOTAL_MEMORY=#{@options.web.total_memory}MB"
     end
 
     @static_links << shell_path
-    @options.fetch("copy_paths", []).each { |path|
+    @options.copy_paths.each { |path|
       @static_links << "--preload-file #{File.join("/", "app", "game", path)}@#{path}"
     }
     @static_links << "-s EXPORT_ALL"
@@ -41,7 +40,7 @@ class WebBuilder < Builder
   end
 
   def name
-    "#{@options["name"]}.html"
+    "#{@options.name}.html"
   end
 end
 

--- a/rakelib/windows.rake
+++ b/rakelib/windows.rake
@@ -10,7 +10,7 @@ class WindowsBuilder < Builder
   end
 
   def name
-    "#{@options["name"]}.exe"
+    "#{@options.name}.exe"
   end
 end
 

--- a/scripts/export/Rakefile
+++ b/scripts/export/Rakefile
@@ -1,47 +1,17 @@
 require "json"
 require "fileutils"
+require_relative "/app/taylor/src/ruby/taylor/config"
 
 def taylor(args)
   `taylor /app/taylor/cli-tool/cli.rb #{args}`
 end
 
-options = {
-  "name" => "taylor_game",
-  "version" => "v0.0.1",
-  "input" => "game.rb",
-  "export_directory" => "./exports",
-  "export_targets" => [
-    "android",
-    "linux",
-    "windows",
-    "osx/intel",
-    "osx/apple",
-    "web"
-  ],
-  "load_paths" => [
-    "./",
-    "./vendor"
-  ],
-  "copy_paths" => [
-    "./assets"
-  ],
-  "debugging" => {
-    "raylib" => {
-      "mock_implementation" => false
-    },
-    "mruby" => {
-      "debug_symbols" => false
-    }
-  }
-}
+options = nil
+Dir.chdir("/app/game") do
+  options = Taylor::Config.new
+end
 
 export_target = ENV.fetch("EXPORT", "linux")
-
-if File.exist?("/app/game/taylor-config.json")
-  options.merge!(
-    JSON.parse(File.read("/app/game/taylor-config.json"))
-  )
-end
 
 task :squash do
   Dir.chdir("/app/game")
@@ -52,7 +22,7 @@ end
 
 task transpile: :squash
 task :transpile do
-  sh "mrbc #{"-g" if options.dig("debugging", "mruby", "debug_symbols")} -Bgame -o /app/taylor/include/game.h /app/taylor/output.rb"
+  sh "mrbc #{"-g" if options.debugging.mruby.debug_symbols?} -Bgame -o /app/taylor/include/game.h /app/taylor/output.rb"
 end
 
 task build: :transpile
@@ -151,7 +121,7 @@ namespace :rename do
       app_path = File.join(
         "/app/game/exports",
         "osx",
-        "#{options["name"]}-intel.app",
+        "#{options.name}-intel.app",
         "Contents",
         "MacOS"
       )
@@ -165,7 +135,7 @@ namespace :rename do
       app_path = File.join(
         "/app/game/exports",
         "osx",
-        "#{options["name"]}-apple.app",
+        "#{options.name}-apple.app",
         "Contents",
         "MacOS"
       )
@@ -194,7 +164,7 @@ namespace :rename do
     puts "Copying web build"
     FileUtils.mkdir_p "/app/game/exports/web"
     FileUtils.cp Dir.glob("/app/taylor/dist/web/release/*"), "/app/game/exports/web"
-    FileUtils.mv File.join("/app/game/exports/web/", "#{options["name"]}.html"),
+    FileUtils.mv File.join("/app/game/exports/web/", "#{options.name}.html"),
       "/app/game/exports/web/index.html"
   end
 end
@@ -224,60 +194,60 @@ namespace :compress do
 
   task :android do
     Dir.chdir("/app/game/exports/android")
-    sh "zip -r \"#{options["name"]}-android-#{options["version"]}.zip\" *"
+    sh "zip -r \"#{options.name}-android-#{options.version}.zip\" *"
   end
 
   namespace :linux do
     task :x64 do
       Dir.chdir("/app/game/exports/linux")
-      options["copy_paths"].each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
-      sh "zip -r \"#{options["name"]}-linux-#{options["version"]}.zip\" *"
+      options.copy_paths.each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
+      sh "zip -r \"#{options.name}-linux-#{options.version}.zip\" *"
     end
   end
 
   task :windows do
     Dir.chdir("/app/game/exports/windows")
-    options["copy_paths"].each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
-    sh "zip -r \"#{options["name"]}-windows-#{options["version"]}.zip\" *"
+    options.copy_paths.each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
+    sh "zip -r \"#{options.name}-windows-#{options.version}.zip\" *"
   end
 
   namespace :osx do
     task :intel do
       Dir.chdir("/app/game/exports/osx")
-      app_path = File.join(".", "#{options["name"]}-intel.app", "Contents", "MacOS")
+      app_path = File.join(".", "#{options.name}-intel.app", "Contents", "MacOS")
       FileUtils.mkdir_p(app_path)
       File.write(File.join(app_path, "..", "PkgInfo"), "APPL????APPL????")
-      options["copy_paths"].each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), app_path) }
-      sh "zip -r \"#{options["name"]}-osx-intel-#{options["version"]}.zip\" *.app"
+      options.copy_paths.each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), app_path) }
+      sh "zip -r \"#{options.name}-osx-intel-#{options.version}.zip\" *.app"
     end
 
     task :apple do
       Dir.chdir("/app/game/exports/osx")
-      app_path = File.join(".", "#{options["name"]}-apple.app", "Contents", "MacOS")
+      app_path = File.join(".", "#{options.name}-apple.app", "Contents", "MacOS")
       FileUtils.mkdir_p(app_path)
       File.write(File.join(app_path, "..", "PkgInfo"), "APPL????APPL????")
-      options["copy_paths"].each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), app_path) }
-      sh "zip -r \"#{options["name"]}-osx-apple-#{options["version"]}.zip\" *.app"
+      options.copy_paths.each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), app_path) }
+      sh "zip -r \"#{options.name}-osx-apple-#{options.version}.zip\" *.app"
     end
 
     namespace :no_app do
       task :intel do
         Dir.chdir("/app/game/exports/osx")
-        options["copy_paths"].each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
-        sh "zip -r \"#{options["name"]}-osx-intel-#{options["version"]}.zip\" taylor"
+        options.copy_paths.each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
+        sh "zip -r \"#{options.name}-osx-intel-#{options.version}.zip\" taylor"
       end
 
       task :apple do
         Dir.chdir("/app/game/exports/osx")
-        options["copy_paths"].each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
-        sh "zip -r \"#{options["name"]}-osx-apple-#{options["version"]}.zip\" taylor"
+        options.copy_paths.each { |asset_path| FileUtils.cp_r(File.join("/app/game/", asset_path), ".") }
+        sh "zip -r \"#{options.name}-osx-apple-#{options.version}.zip\" taylor"
       end
     end
   end
 
   task :web do
     Dir.chdir("/app/game/exports/web")
-    sh "zip -r \"#{options["name"]}-web-#{options["version"]}.zip\" *"
+    sh "zip -r \"#{options.name}-web-#{options.version}.zip\" *"
   end
 end
 

--- a/src/ruby/taylor/config.rb
+++ b/src/ruby/taylor/config.rb
@@ -66,6 +66,7 @@ module Taylor
     #
     # @return [String]
     def export_directory
+      @export_directory ||= old_key_check("export-directory")
       @export_directory ||= @config.fetch("export_directory", "./exports")
     end
 
@@ -77,10 +78,12 @@ module Taylor
     #
     # @return [Array<String>]
     def export_targets
+      @export_targets ||= old_key_check("export-targets")
       @export_targets ||= @config.fetch("export_targets", ["linux", "windows", "osx/apple", "osx/intel", "web"])
     end
 
-    # Returns the load paths of the Taylor game.
+    # Returns the load paths of the Taylor game. These are the paths that
+    # Taylor will look for `.rb` files when exporting the game.
     #
     # @example Basic usage
     #   puts Taylor::Config.new.load_paths
@@ -88,10 +91,12 @@ module Taylor
     #
     # @return [Array<String>]
     def load_paths
+      @load_paths ||= old_key_check("load-paths")
       @load_paths ||= @config.fetch("load_paths", ["./", "./vendor"])
     end
 
-    # Returns the copy paths of the Taylor game.
+    # Returns the copy paths of the Taylor game. These are things like assets
+    # that you want copied into the exported game.
     #
     # @example Basic usage
     #   puts Taylor::Config.new.copy_paths
@@ -99,7 +104,22 @@ module Taylor
     #
     # @return [Array<String>]
     def copy_paths
+      @copy_paths ||= old_key_check("copy-paths")
       @copy_paths ||= @config.fetch("copy_paths", ["./assets"])
+    end
+
+    private
+
+    def old_key_check(key)
+      if @config.has_key?(key)
+        if Object.const_defined?(:TAYLOR_VERSION)
+          Logging.log(
+            message: "Old key '#{key}' used, please use '#{key.tr("-", "_")}'",
+            level: Logging::WARNING
+          )
+        end
+        @config[key]
+      end
     end
 
     # The {Web} class is used for all the configuration about this Taylor game
@@ -121,9 +141,9 @@ module Taylor
       #   puts Taylor::Config.new.web.shell_path
       #   # => "./scripts/export/emscripten_shell.html"
       #
-      # @return [String]
+      # @return [String,nil]
       def shell_path
-        @shell_path ||= @config.fetch("shell_path", "./scripts/export/emscripten_shell.html")
+        @shell_path ||= @config.fetch("shell_path", nil)
       end
 
       # Returns the total allowed memory of the Taylor game web export.
@@ -168,7 +188,7 @@ module Taylor
         #   # => false
         #
         # @return [Boolean]
-        def mock_implementation
+        def mock_implementation?
           if instance_variable_defined? :@mock_implementation
             @mock_implementation
           else
@@ -196,7 +216,7 @@ module Taylor
         #   # => false
         #
         # @return [Boolean]
-        def debug_symbols
+        def debug_symbols?
           if instance_variable_defined? :@debug_symbols
             @debug_symbols
           else

--- a/taylor-config.json
+++ b/taylor-config.json
@@ -1,0 +1,3 @@
+{
+  "name": "taylor"
+}

--- a/test/taylor/config_test.rb
+++ b/test/taylor/config_test.rb
@@ -15,10 +15,10 @@
     expect(config.export_targets).to_equal(["linux", "windows", "osx/apple", "osx/intel", "web"])
     expect(config.load_paths).to_equal(["./", "./vendor"])
     expect(config.copy_paths).to_equal(["./assets"])
-    expect(config.web.shell_path).to_equal("./scripts/export/emscripten_shell.html")
+    expect(config.web.shell_path).to_be_nil
     expect(config.web.total_memory).to_equal(64)
-    expect(config.debugging.raylib.mock_implementation).to_be_false
-    expect(config.debugging.mruby.debug_symbols).to_be_false
+    expect(config.debugging.raylib.mock_implementation?).to_be_false
+    expect(config.debugging.mruby.debug_symbols?).to_be_false
   end
 
   But "When we have a taylor-config.json file" do
@@ -58,8 +58,8 @@
     expect(config.copy_paths).to_equal(["copy", "paths"])
     expect(config.web.shell_path).to_equal("shell_path")
     expect(config.web.total_memory).to_equal(128)
-    expect(config.debugging.raylib.mock_implementation).to_be_true
-    expect(config.debugging.mruby.debug_symbols).to_be_true
+    expect(config.debugging.raylib.mock_implementation?).to_be_true
+    expect(config.debugging.mruby.debug_symbols?).to_be_true
   end
 
   When "we override the options" do
@@ -88,8 +88,37 @@
     expect(@config.copy_paths).to_equal(["manual", "copy", "paths"])
     expect(@config.web.shell_path).to_equal("manual shell_path")
     expect(@config.web.total_memory).to_equal(256)
-    expect(@config.debugging.raylib.mock_implementation).to_be_false
-    expect(@config.debugging.mruby.debug_symbols).to_be_false
+    expect(@config.debugging.raylib.mock_implementation?).to_be_false
+    expect(@config.debugging.mruby.debug_symbols?).to_be_false
+  end
+
+  But "when we have the old keys" do
+    config = File.open("taylor-config.json", "w")
+    config.write({
+      "export-directory" => "export-directory",
+      "export-targets" => ["export-targets"],
+      "load-paths" => ["load-paths"],
+      "copy-paths" => ["copy-paths"]
+    }.to_json)
+    config.close
+  end
+
+  Then "we load the data" do
+    @config = Taylor::Config.new
+
+    expect(@config.export_directory).to_equal("export-directory")
+    expect(@config.export_targets).to_equal(["export-targets"])
+    expect(@config.load_paths).to_equal(["load-paths"])
+    expect(@config.copy_paths).to_equal(["copy-paths"])
+  end
+
+  But "we warn the user" do
+    calls = Taylor::Raylib.calls
+    expect(calls.size).to_equal(4)
+    expect(calls[0]).to_equal("(TraceLog) { logLevel: 4 text: 'Old key 'export-directory' used, please use 'export_directory'' }")
+    expect(calls[1]).to_equal("(TraceLog) { logLevel: 4 text: 'Old key 'export-targets' used, please use 'export_targets'' }")
+    expect(calls[2]).to_equal("(TraceLog) { logLevel: 4 text: 'Old key 'load-paths' used, please use 'load_paths'' }")
+    expect(calls[3]).to_equal("(TraceLog) { logLevel: 4 text: 'Old key 'copy-paths' used, please use 'copy_paths'' }")
   end
 ensure
   Dir.chdir("..")


### PR DESCRIPTION
## What's the Change?

Since I was handling the `taylor-config.json` file in multiple different ways this lead to a bunch of discrepancies I didn't notice. Now everywhere goes through the `Taylor::Config` class as much as possible.

I have raised a warning when I detect a user with one of the old keys too.

This resolves:
  - #68 - config seemingly ignored
  - #69 - fonts not appearing in web exports

## Checklist

- [x] Added tests
- [x] Added documentation
- [x] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [x] Added an entry to `changelog.md`
- [x] Run `dx/exec bundle exec rake ci`
