### PR TITLE
Properly accept the --entrypoint flag for taylor run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Upgraded MRuby to 4.0.0
 - Upgraded Raylib to 6.0
+- CLI now properly accepts the `--entrypoint` flag
 
 ## v0.4.3
 

--- a/cli-tool/app/commands/run.rb
+++ b/cli-tool/app/commands/run.rb
@@ -10,7 +10,12 @@ module Taylor
         @argv = argv
         setup_options(@argv, options)
 
-        @command = command || ""
+        @command = case command
+        when "--entrypoint"
+          ""
+        else
+          command || ""
+        end
 
         if @options[:help] || entrypoint.empty?
           display_help
@@ -50,17 +55,17 @@ module Taylor
       private
 
       def entrypoint
-        if !@command.empty?
-          if File.directory?(@command) && File.exist?(File.join(@command, "taylor-config.json"))
-            Dir.chdir(@command)
-            setup_options(@argv, Taylor::Config.new)
-            $:.unshift "."
-            @options[:entrypoint]
-          else
-            @command
-          end
-        else
+        if @command.empty?
           @options[:entrypoint]
+
+        elsif File.directory?(@command) && File.exist?(File.join(@command, "taylor-config.json"))
+          Dir.chdir(@command)
+          setup_options(@argv, Taylor::Config.new)
+          $:.unshift "."
+          @options[:entrypoint]
+
+        else
+          @command
         end
       end
 

--- a/cli-tool/test/commands/run_test.rb
+++ b/cli-tool/test/commands/run_test.rb
@@ -57,6 +57,14 @@ end
     expect(@run_command.require_list).to_equal(["./cli.rb"])
   end
 
+  When "we pass a file by entrypoint" do
+    @run_command = Taylor::Commands::Run.new("--entrypoint", ["--entrypoint", "test/test.rb"], Taylor::Config.new)
+  end
+
+  Then "require the file in the options" do
+    expect(@run_command.require_list).to_equal(["test/test.rb"])
+  end
+
   When "we pass a file that doesn't exist" do
     @run_command = Taylor::Commands::Run.new("./non_existant.rb", [], Taylor::Config.new)
   end


### PR DESCRIPTION
## What's the Change?

The taylor CLI should accept the `--entrypoint` flag like the help document says. This change makes that work properly

## Checklist

- [X] Added tests
- [ ] Added documentation
- [ ] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [X] Added an entry to `changelog.md`
- [ ] Run `dx/exec bundle exec rake ci`
