### PR TITLE
Support "--" in taylor cli to disambiguate arguments for taylor versus arguments for the game

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgraded Raylib to 6.0
 - CLI now properly accepts the `--entrypoint` flag
 - Upgraded emscripten to 6.0.0
+- CLI now accepts '--' to distinguish taylor arguments from entrypoint arguments
 
 ## v0.4.3
 

--- a/cli-tool/app/commands/run.rb
+++ b/cli-tool/app/commands/run.rb
@@ -6,15 +6,16 @@ module Taylor
       end
 
       attr_accessor :options
-      def initialize(command, argv, options)
-        @argv = argv
-        setup_options(@argv, options)
 
-        @command = case command
-        when "--entrypoint"
+      def initialize(command, argv, options)
+        setup_argvs(argv)
+        setup_options(options)
+
+        # better name for command might be something like "game_directory_or_entrypoint"
+        @command = if command.nil? || command.start_with?("--")
           ""
         else
-          command || ""
+          command
         end
 
         if @options[:help] || entrypoint.empty?
@@ -69,12 +70,25 @@ module Taylor
         end
       end
 
-      def setup_options(argv, options)
+      def setup_argvs(argv)
+        @argv = argv
+
+        argument_separator_index = @argv.index("--")
+
+        if argument_separator_index
+          @argv_for_command = @argv[0...argument_separator_index]
+          @argv_for_entrypoint = @argv[(argument_separator_index + 1)..]
+        else
+          @argv_for_command = @argv
+        end
+      end
+
+      def setup_options(options)
         parser = OptParser.new do |opts|
           opts.on(:help, :bool, false, short: :h)
           opts.on(:entrypoint, :string, options.entrypoint, short: :e)
         end
-        parser.parse(argv)
+        parser.parse(@argv_for_command)
 
         @options = parser.opts
       end
@@ -89,12 +103,24 @@ module Taylor
 
       def run_command
         if File.exist?(entrypoint)
-          ARGV.shift
-          require entrypoint
+          set_argv_for_entrypoint
 
+          require entrypoint
         else
           puts "Could not load \"#{entrypoint}\", are you sure it exists?"
           exit! 1
+        end
+      end
+
+      def set_argv_for_entrypoint
+        if @argv_for_entrypoint
+          ARGV.clear
+          @argv_for_entrypoint.each.with_index do |arg, index|
+            ARGV[index] = arg
+          end
+        else
+          # This is the behavior before supporting "--" so just preserving it for now.
+          ARGV.shift
         end
       end
     end

--- a/cli-tool/test/commands/run_test.rb
+++ b/cli-tool/test/commands/run_test.rb
@@ -72,4 +72,32 @@ end
   Then "we exit with an error" do
     expect(@run_command.exit_status).to_equal(1)
   end
+
+  When "we pass specify arguments for the entrypoint via --" do
+    @run_command = Taylor::Commands::Run.new(
+      "--entrypoint",
+      ["--entrypoint", "test/test.rb", "--", "-a", "arg1", "arg2"],
+      Taylor::Config.new
+    )
+  end
+
+  Then "ARGV is manipulated for the entrypoint after we've parsed the run opts" do
+    expect(@run_command.require_list).to_equal(["test/test.rb"])
+    expect(ARGV).to_equal(["-a", "arg1", "arg2"])
+    expect(@run_command.options[:entrypoint]).to_equal("test/test.rb")
+  end
+
+  When "we pass specify arguments for the entrypoint via -- without any options for the command" do
+    @run_command = Taylor::Commands::Run.new(
+      "--",
+      ["--", "--entrypoint", "arg1", "-h"],
+      Taylor::Config.new
+    )
+  end
+
+  Then "ARGV is manipulated to contain all the args" do
+    expect(ARGV).to_equal(["--entrypoint", "arg1", "-h"])
+    expect(@run_command.options).to_equal(help: false, entrypoint: "cli.rb")
+    expect(@run_command.require_list).to_equal(["cli.rb"])
+  end
 end


### PR DESCRIPTION
## What's the Change?

Before I had to do: `taylor game.rb localhost` (not a big deal)

But now I can do `taylor -- localhost` to pass localhost through to my game. Which feels more intuitive.

Note, I also did a follow-up opportunistic refactor commit to get rid of the seemingly-unnecessary/confusing "command" parameter to `Run`. You can review the commits separately if you don't like the refactor or also I'm happy to tweak stuff based on feedback.

I also streamed working on this so I have video of the whole thing, ha. It's 4 hours total though. But if curious to click around in it I can share!

## Checklist

- [x] Added tests

- [ ] Added documentation
^ I suppose I could update the help output to mention this feature. Let me know if I should.

- [ ] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
^ This one is likely irrelevant

- [x] Added an entry to `changelog.md`

Re:

- [ ] Run `dx/exec bundle exec rake ci`

`rake ci:testing` passes and I added a couple tests for this. I can't get a passing `rake ci` due to clang-format errors. My clang-format version is 19.1.7.

I also ran `rake` to build taylor and tested it with `~/gitlocal/ruby/Taylor/dist/linux/debug/taylor ~/gitlocal/ruby/Taylor/cli-tool/cli.rb -- localhost` to verify it works.

Running `dx/exec bundle exec rake ci` like in the template item gave me the following error:

```
╚dx/exec bundle exec rake ci
[ dx/exec ] Using 1000:1000 since we're on Linux
[ dx/exec ] Docker is installed!
[ dx/exec ] Executing 'bundle exec rake ci' inside of container with service named 'app'
service "app" is not running
```

Likely I'm missing some basic step to get that thing running first? This isn't related to my change. I assumed that a local `rake ci:testing` was probably good enough for a change like this but let me know.