### PR TITLE
Fix incorrect arg requirements for Window.draw_frame_rate

### DIFF
--- a/src/mruby_integration/models/window.cpp
+++ b/src/mruby_integration/models/window.cpp
@@ -486,7 +486,7 @@ void append_models_Window(mrb_state* mrb)
   mrb_define_class_method(
     mrb, Window_class, "seconds_open", mrb_Window_seconds_open, MRB_ARGS_NONE());
   mrb_define_class_method(
-    mrb, Window_class, "draw_frame_rate", mrb_Window_draw_frame_rate, MRB_ARGS_REQ(1));
+    mrb, Window_class, "draw_frame_rate", mrb_Window_draw_frame_rate, MRB_ARGS_OPT(1));
 
   load_ruby_models_window(mrb);
 }


### PR DESCRIPTION
On `Taylor 0.5.0-pre` I got an unexpected error when using `Window.draw_frame_rate` without any arguments.

This seems to fix it! Though not certain if it's the right fix for this kind of thing.

I tested it manually by building taylor with `rake` but no clue if there's automated tests for this kind of thing or not.