### PR TITLE
Add missing "-v", the short CLI option form of "--version"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Upgraded Raylib to 6.0
 - CLI now properly accepts the `--entrypoint` flag
 - Upgraded emscripten to 6.0.0
+- Fix -v short option for --version
 
 ## v0.4.3
 

--- a/cli-tool/cli.rb
+++ b/cli-tool/cli.rb
@@ -37,7 +37,7 @@ when "export"
 when "squash"
   Taylor::Commands::Squash.call(ARGV[1..], options)
 
-when "--version"
+when "--version", "-v"
   Taylor::Commands::Version.call
 
 else


### PR DESCRIPTION
## What's the Change?

This makes `-v` work.

Currently, `taylor -h` gives the following output:

```
╚taylor -h
Taylor 0.4.3

Usage:
  taylor			# If the current folder is a taylor game, launch it
  taylor ./game.rb		# Launch ./game.rb
  taylor --entrypoint ./game.rb	# Launch ./game.rb
  taylor <action> [options]

Options:
  -h, --help			Show this message
  -v, --version			Display the version and exit
  -e, --entrypoint entrypoint	What is the name of the entrypoint file (defaults to game.rb)

Actions:
  new		Create a new Taylor game
  export	Compile your game for release
  squash	Squash all your source code into one file
```

Of these short options, `-e` and `-h` work but `-v` does not.

Note: this was extracted from a PR where it was rejected because short options had been decided against. I think if not wanting to support `-v` then the help output should remove it. And if all short options are undesirable then `-e` and `-h` should be removed. My preference is to call `taylor -v` when I need to know its version and `taylor --version` when I need something self-documenting like in a script. I like having both options and `taylor -v` is faster to type and fairly standard.

## Checklist

- [ ] Added tests
- [ ] Added documentation
- [ ] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [x] Added an entry to `changelog.md`
- [ ] Run `dx/exec bundle exec rake ci`
