### PR TITLE
Remove first parameter to Run

### DIFF
--- a/cli-tool/app/commands/run.rb
+++ b/cli-tool/app/commands/run.rb
@@ -1,22 +1,19 @@
 module Taylor
   module Commands
     class Run
-      def self.call(command, argv, options)
-        new(command, argv, options)
+      def self.call(argv, options)
+        new(argv, options)
       end
 
       attr_accessor :options
 
-      def initialize(command, argv, options)
-        setup_argvs(argv)
-        setup_options(options)
+      def initialize(argv, taylor_config)
+        @argv = Array(argv)
+        @taylor_config = taylor_config
 
-        # better name for command might be something like "game_directory_or_entrypoint"
-        @command = if command.nil? || command.start_with?("--")
-          ""
-        else
-          command
-        end
+        setup_argvs
+        setup_entrypoint
+        setup_options
 
         if @options[:help] || entrypoint.empty?
           display_help
@@ -55,24 +52,31 @@ module Taylor
 
       private
 
-      def entrypoint
-        if @command.empty?
-          @options[:entrypoint]
+      def setup_entrypoint
+        first_arg = @argv_for_command[0]
 
-        elsif File.directory?(@command) && File.exist?(File.join(@command, "taylor-config.json"))
-          Dir.chdir(@command)
-          setup_options(@argv, Taylor::Config.new)
+        return unless first_arg
+        return if first_arg[0] == "-"
+
+        if File.directory?(first_arg)
+          return unless File.exist?(File.join(first_arg, "taylor-config.json"))
+
+          Dir.chdir(first_arg)
+          @argv_for_command.shift
+          @taylor_config = Taylor::Config.new
+
           $:.unshift "."
-          @options[:entrypoint]
-
         else
-          @command
+          @argv_for_command.shift
+          @entrypoint = first_arg
         end
       end
 
-      def setup_argvs(argv)
-        @argv = argv
+      def entrypoint
+        @options[:entrypoint]
+      end
 
+      def setup_argvs
         argument_separator_index = @argv.index("--")
 
         if argument_separator_index
@@ -83,18 +87,14 @@ module Taylor
         end
       end
 
-      def setup_options(options)
+      def setup_options
         parser = OptParser.new do |opts|
           opts.on(:help, :bool, false, short: :h)
-          opts.on(:entrypoint, :string, options.entrypoint, short: :e)
+          opts.on(:entrypoint, :string, @entrypoint || @taylor_config.entrypoint, short: :e)
         end
         parser.parse(@argv_for_command)
 
         @options = parser.opts
-      end
-
-      def from_config
-        @options["entrypoint"]
       end
 
       def unload_taylor_cli
@@ -118,9 +118,6 @@ module Taylor
           @argv_for_entrypoint.each.with_index do |arg, index|
             ARGV[index] = arg
           end
-        else
-          # This is the behavior before supporting "--" so just preserving it for now.
-          ARGV.shift
         end
       end
     end

--- a/cli-tool/cli.rb
+++ b/cli-tool/cli.rb
@@ -41,5 +41,5 @@ when "--version", "-v"
   Taylor::Commands::Version.call
 
 else
-  Taylor::Commands::Run.call(command, ARGV, options)
+  Taylor::Commands::Run.call(ARGV, options)
 end

--- a/cli-tool/test/commands/run_test.rb
+++ b/cli-tool/test/commands/run_test.rb
@@ -1,6 +1,6 @@
 @unit.describe "Run --help" do
   Given "We have run `taylor --help`" do
-    @run_command = Taylor::Commands::Run.new("./cli.rb", ["--help"], Taylor::Config.new)
+    @run_command = Taylor::Commands::Run.new(["./cli.rb", "--help"], Taylor::Config.new)
   end
 
   Then "we return useful information" do
@@ -32,7 +32,7 @@ end
 @unit.describe "Run" do
   When "we call run" do
     Taylor.removed_constants = []
-    Taylor::Commands::Run.new("./cli.rb", [], Taylor::Config.new)
+    Taylor::Commands::Run.new("./cli.rb", Taylor::Config.new)
   end
 
   Then "remove the 'Command' constant" do
@@ -40,7 +40,7 @@ end
   end
 
   When "we pass a filename" do
-    @run_command = Taylor::Commands::Run.new("./test/test.rb", [], Taylor::Config.new)
+    @run_command = Taylor::Commands::Run.new("./test/test.rb", Taylor::Config.new)
   end
 
   Then "we require that file" do
@@ -50,7 +50,7 @@ end
   When "we don't pass a filename" do
     config = Taylor::Config.new
     config.entrypoint = "./cli.rb"
-    @run_command = Taylor::Commands::Run.new(nil, [], config)
+    @run_command = Taylor::Commands::Run.new([], config)
   end
 
   Then "require the file in the options" do
@@ -58,7 +58,7 @@ end
   end
 
   When "we pass a file by entrypoint" do
-    @run_command = Taylor::Commands::Run.new("--entrypoint", ["--entrypoint", "test/test.rb"], Taylor::Config.new)
+    @run_command = Taylor::Commands::Run.new(["--entrypoint", "test/test.rb"], Taylor::Config.new)
   end
 
   Then "require the file in the options" do
@@ -66,7 +66,7 @@ end
   end
 
   When "we pass a file that doesn't exist" do
-    @run_command = Taylor::Commands::Run.new("./non_existant.rb", [], Taylor::Config.new)
+    @run_command = Taylor::Commands::Run.new("./non_existant.rb", Taylor::Config.new)
   end
 
   Then "we exit with an error" do
@@ -75,7 +75,6 @@ end
 
   When "we pass specify arguments for the entrypoint via --" do
     @run_command = Taylor::Commands::Run.new(
-      "--entrypoint",
       ["--entrypoint", "test/test.rb", "--", "-a", "arg1", "arg2"],
       Taylor::Config.new
     )
@@ -88,11 +87,7 @@ end
   end
 
   When "we pass specify arguments for the entrypoint via -- without any options for the command" do
-    @run_command = Taylor::Commands::Run.new(
-      "--",
-      ["--", "--entrypoint", "arg1", "-h"],
-      Taylor::Config.new
-    )
+    @run_command = Taylor::Commands::Run.new(["--", "--entrypoint", "arg1", "-h"], Taylor::Config.new)
   end
 
   Then "ARGV is manipulated to contain all the args" do


### PR DESCRIPTION
## What's the Change?

This removes the first parameter to `Run`. It's redundant with a misleading name so this reduces confusion. This was extracted from the "--" PR to make that simpler but wanted to open a PR with that commit for re-consideration in isolation from the other changes.

The command parameter doesn't actually represent a command. A more descriptive name would be something like `working_directory_or_entry_point_or_switch_of_first_cli_option` though obviously too long so a shorter name for that would be something like `first_arg`. The `argv` parameter already contains this along with other args. Exposing this through Run's public interface imposes this confusion on the calling code such that it has to know to always pass the first argv as both the first parameter to `Run` as well as the first element of the second parameter to `Run` otherwise things don't work. And calling it `command` instead of `first_arg` increases the confusion.

## Checklist

- [x] Added tests

^ Technically just updated existing tests that were added in the PR this was extracted from

- [ ] Added documentation
- [ ] Updated `migrations/0_4_to_0_5.md` if it's a breaking change
- [ ] Added an entry to `changelog.md`

^ Seems like for an internal interface change like this there's probably not much value of adding it to the changelog but can if desired of course.

- [ ] Run `dx/exec bundle exec rake ci`

^ running this command locally doesn't seem to do anything useful.